### PR TITLE
fix(a11y-journey): surface journey fields in JSON output

### DIFF
--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -162,6 +162,15 @@ pub struct PageEntry {
     pub principle_coverage: crate::audit::PrincipleCoverage,
     pub findings: Vec<crate::audit::normalized::NormalizedFinding>,
     pub audit_flags: Vec<crate::audit::normalized::AuditFlag>,
+    /// Findings produced by the Accessibility-Journey-Layer (phase 2+).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub interactive_findings: Vec<crate::audit::normalized::InteractiveFinding>,
+    /// Reproducible journey traces. Present only when `--interactive != off`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accessibility_journey: Option<crate::audit::normalized::AccessibilityJourney>,
+    /// Advisory (semantic / LLM) findings. Never affect score or risk.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub advisory_findings: Vec<crate::audit::normalized::AdvisoryFinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<PageDetail>,
 }
@@ -594,6 +603,9 @@ fn build_page(normalized: &NormalizedReport, ctx: Option<DetailContext>) -> Page
         principle_coverage: normalized.principle_coverage.clone(),
         findings: normalized.findings.clone(),
         audit_flags: normalized.audit_flags.clone(),
+        interactive_findings: normalized.interactive_findings.clone(),
+        accessibility_journey: normalized.accessibility_journey.clone(),
+        advisory_findings: normalized.advisory_findings.clone(),
         detail,
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 (#293) wired the Accessibility-Journey-Layer through to
`NormalizedReport` but missed the JSON serialization layer:
`PageEntry` in `src/output/json.rs` never copied `accessibility_journey`,
`interactive_findings` or `advisory_findings` from the normalized
report. As a result, JSON consumers saw no journey trace at all even
with `--interactive=basic`.

This PR adds the three fields to `PageEntry` and propagates them from
`NormalizedReport` in `build_page()`. All three have
`#[serde(skip_serializing_if = ...)]` so the JSON shape is unchanged
for `--interactive=off` (default).

## Verification

Built locally and ran:

```
auditmysite https://www.casoon.de --interactive=basic --format json \
  --output reports/casoon-interactive-smoke.json
```

JSON output now contains:

```
accessibility_journey present: True
  traces: 1
  - journey='tab_walk', steps=26
    first 3 steps:
      {'action': 'start', 'snapshot_label': 'initial'}
      {'action': 'tab', 'focus': 'html > body > a',
       'snapshot_label': 'after_tab_1'}
      {'action': 'tab', 'focus': 'div#site-content > div > a',
       'snapshot_label': 'after_tab_2'}
interactive_findings: 0   # correct — phase 1 records, phase 2 evaluates
```

25 tab presses, sensible selectors, no stuck/loop. Trace is the
reproducible evidence phases 2–5 will build findings on.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] Manual smoke test against `www.casoon.de` with `--interactive=basic`
- [x] Manual smoke test against `www.casoon.de` *without*
      `--interactive` (default `off`) — JSON shape unchanged, no
      `accessibility_journey` field emitted