### PR TITLE
feat(a11y-journey): Phase 2 — Tab-Walk evaluation, pattern journeys, interactive findings

### DIFF
--- a/src/a11y_journey/disclosure_journey.rs
+++ b/src/a11y_journey/disclosure_journey.rs
@@ -158,8 +158,7 @@ pub async fn test(
             journey: journey_name,
             before_snapshot_label: Some("after_open_click".to_string()),
             after_snapshot_label: Some("after_close_click".to_string()),
-            message: "Disclosure does not toggle closed on second activation."
-                .to_string(),
+            message: "Disclosure does not toggle closed on second activation.".to_string(),
             fix_suggestion: Some(
                 "Ensure the click handler toggles aria-expanded between true and false."
                     .to_string(),
@@ -169,4 +168,3 @@ pub async fn test(
 
     Ok((trace, findings))
 }
-

--- a/src/a11y_journey/disclosure_journey.rs
+++ b/src/a11y_journey/disclosure_journey.rs
@@ -1,0 +1,172 @@
+//! Disclosure / accordion journey: click trigger, verify aria-expanded toggles.
+
+use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
+use chromiumoxide::Page;
+
+use crate::audit::normalized::{InteractiveFinding, JourneyStep, JourneyTrace};
+use crate::error::Result;
+use crate::interaction::{pointer, stability};
+use crate::patterns::JourneyCandidate;
+use crate::taxonomy::Severity;
+
+/// JS that collects all `[aria-expanded]` buttons and their current state.
+const COLLECT_EXPANDED_JS: &str = r#"
+(function() {
+    var els = Array.from(document.querySelectorAll('[aria-expanded]'));
+    return els.map(function(e) {
+        return e.getAttribute('aria-expanded');
+    });
+})()
+"#;
+
+async fn collect_expanded_states(page: &Page) -> Option<Vec<String>> {
+    let params = EvaluateParams::builder()
+        .expression(COLLECT_EXPANDED_JS.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    let value = result.result.result.value?;
+    let arr = value.as_array()?;
+    Some(
+        arr.iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+    )
+}
+
+pub async fn test(
+    page: &Page,
+    candidate: &JourneyCandidate,
+    index: usize,
+) -> Result<(JourneyTrace, Vec<InteractiveFinding>)> {
+    let journey_name = format!("disclosure_{index}");
+    let mut trace = JourneyTrace {
+        journey: journey_name.clone(),
+        steps: Vec::new(),
+    };
+    let mut findings: Vec<InteractiveFinding> = Vec::new();
+
+    let trigger_id = match candidate.trigger_backend_id {
+        Some(id) => id,
+        None => return Ok((trace, findings)),
+    };
+
+    // Capture state before first click.
+    let before_states = collect_expanded_states(page).await;
+
+    // First click: should open the disclosure.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("disclosure: click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_open_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    let after_open_states = collect_expanded_states(page).await;
+
+    // Check whether any button flipped from "false" to "true".
+    let opened = match (&before_states, &after_open_states) {
+        (Some(before), Some(after)) => before
+            .iter()
+            .zip(after.iter())
+            .any(|(b, a)| b == "false" && a == "true"),
+        // If we couldn't read states, assume it may have worked (no false positive).
+        _ => true,
+    };
+
+    trace.steps.push(JourneyStep {
+        action: "check_expanded".to_string(),
+        target: None,
+        focus: None,
+        result: Some(if opened {
+            "expanded_true".to_string()
+        } else {
+            "expanded_unchanged".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !opened {
+        findings.push(InteractiveFinding {
+            category: "StateTransition".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_open_click".to_string()),
+            message: "Disclosure button was clicked but aria-expanded did not change. \
+                State transition is not announced to screen readers."
+                .to_string(),
+            fix_suggestion: Some(
+                "Toggle aria-expanded=\"true|false\" on the button in the click handler."
+                    .to_string(),
+            ),
+        });
+        // Skip the second click if the first didn't work.
+        return Ok((trace, findings));
+    }
+
+    // Second click: should close the disclosure.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("disclosure: second click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_close_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    let after_close_states = collect_expanded_states(page).await;
+
+    // Check whether it returned to closed (flipped back from "true" to "false").
+    let closed = match (&after_open_states, &after_close_states) {
+        (Some(open), Some(closed)) => open
+            .iter()
+            .zip(closed.iter())
+            .any(|(o, c)| o == "true" && c == "false"),
+        _ => true,
+    };
+
+    trace.steps.push(JourneyStep {
+        action: "check_collapsed".to_string(),
+        target: None,
+        focus: None,
+        result: Some(if closed {
+            "collapsed_true".to_string()
+        } else {
+            "collapsed_failed".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !closed {
+        findings.push(InteractiveFinding {
+            category: "StateTransition".to_string(),
+            severity: Severity::Medium,
+            journey: journey_name,
+            before_snapshot_label: Some("after_open_click".to_string()),
+            after_snapshot_label: Some("after_close_click".to_string()),
+            message: "Disclosure does not toggle closed on second activation."
+                .to_string(),
+            fix_suggestion: Some(
+                "Ensure the click handler toggles aria-expanded between true and false."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok((trace, findings))
+}
+

--- a/src/a11y_journey/evaluate.rs
+++ b/src/a11y_journey/evaluate.rs
@@ -1,0 +1,190 @@
+//! Turns recorded journey traces + focus snapshots into
+//! `InteractiveFinding`s.
+//!
+//! Each evaluator function takes the *evidence* from a journey runner
+//! and produces findings without itself touching the browser. That keeps
+//! the runtime side effects (CDP, JS evaluate, …) and the evaluation
+//! logic in separate, testable units.
+//!
+//! Phase 2a covers:
+//! - hidden focusables (aria-hidden, inert, hidden-by-style)
+//! - focus reaching `body` after the walk (focus loss)
+//!
+//! Focus-indicator detection and out-of-order detection land in
+//! separate evaluators in Phase 2a follow-up commits.
+
+use crate::accessibility::FocusSnapshot;
+use crate::audit::normalized::{InteractiveFinding, JourneyTrace};
+use crate::taxonomy::Severity;
+
+/// Evaluate a tab-walk trace and its per-step focus snapshots.
+///
+/// Pure function: deterministic given the inputs. No browser calls.
+pub fn tab_walk(trace: &JourneyTrace, snapshots: &[FocusSnapshot]) -> Vec<InteractiveFinding> {
+    let mut findings = Vec::new();
+
+    // Walk steps + snapshots in lockstep. `trace.steps[i]` corresponds to
+    // `snapshots[i]` by construction in `tab_walk::record`.
+    for (step, snap) in trace.steps.iter().zip(snapshots.iter()) {
+        // Hidden focusables are only meaningful for tab-press steps. The
+        // "start" step records the initial state and isn't an interaction.
+        if step.action != "tab" {
+            continue;
+        }
+        let Some(selector) = &step.focus else {
+            continue;
+        };
+
+        if snap.aria_hidden_chain {
+            findings.push(InteractiveFinding {
+                category: "HiddenFocusable".to_string(),
+                severity: Severity::High,
+                journey: trace.journey.clone(),
+                before_snapshot_label: None,
+                after_snapshot_label: step.snapshot_label.clone(),
+                message: format!(
+                    "Tastatur-Fokus landet auf einem Element innerhalb \
+                     eines aria-hidden-Bereichs ({selector}). Screenreader-Nutzer \
+                     erreichen ein vom AXTree ausgeblendetes Element."
+                ),
+                fix_suggestion: Some(
+                    "Element aus aria-hidden-Bereich entfernen oder \
+                     tabindex=\"-1\" setzen."
+                        .to_string(),
+                ),
+            });
+        } else if snap.inert_chain {
+            findings.push(InteractiveFinding {
+                category: "HiddenFocusable".to_string(),
+                severity: Severity::High,
+                journey: trace.journey.clone(),
+                before_snapshot_label: None,
+                after_snapshot_label: step.snapshot_label.clone(),
+                message: format!(
+                    "Tastatur-Fokus landet auf einem Element innerhalb \
+                     eines inert-Bereichs ({selector}). Inert-Bereiche \
+                     sollten nicht erreichbar sein."
+                ),
+                fix_suggestion: Some(
+                    "Element aus inert-Bereich nehmen oder \
+                     tabindex/Fokus-Kette korrigieren."
+                        .to_string(),
+                ),
+            });
+        } else if snap.hidden_by_style {
+            findings.push(InteractiveFinding {
+                category: "HiddenFocusable".to_string(),
+                severity: Severity::Medium,
+                journey: trace.journey.clone(),
+                before_snapshot_label: None,
+                after_snapshot_label: step.snapshot_label.clone(),
+                message: format!(
+                    "Tastatur-Fokus landet auf einem visuell verborgenen \
+                     Element ({selector}: display:none, visibility:hidden \
+                     oder opacity:0). Tastatur-Nutzer verlieren die \
+                     Orientierung."
+                ),
+                fix_suggestion: Some(
+                    "Element aus Tab-Sequenz entfernen (tabindex=\"-1\") \
+                     oder erst sichtbar machen."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::normalized::JourneyStep;
+
+    fn step_tab(selector: &str, label: &str) -> JourneyStep {
+        JourneyStep {
+            action: "tab".to_string(),
+            target: None,
+            focus: Some(selector.to_string()),
+            result: None,
+            snapshot_label: Some(label.to_string()),
+        }
+    }
+
+    fn snap_with(aria: bool, inert: bool, hidden: bool) -> FocusSnapshot {
+        FocusSnapshot {
+            selector: Some("a".to_string()),
+            aria_hidden_chain: aria,
+            inert_chain: inert,
+            hidden_by_style: hidden,
+            ..Default::default()
+        }
+    }
+
+    fn trace_with(steps: Vec<JourneyStep>) -> JourneyTrace {
+        JourneyTrace {
+            journey: "tab_walk".to_string(),
+            steps,
+        }
+    }
+
+    #[test]
+    fn clean_walk_produces_no_findings() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_with(false, false, false)];
+        assert!(tab_walk(&trace, &snaps).is_empty());
+    }
+
+    #[test]
+    fn aria_hidden_chain_emits_high_finding() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_with(true, false, false)];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].category, "HiddenFocusable");
+        assert_eq!(findings[0].severity, Severity::High);
+        assert!(findings[0].message.contains("aria-hidden"));
+    }
+
+    #[test]
+    fn inert_chain_emits_high_finding() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_with(false, true, false)];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].message.contains("inert"));
+    }
+
+    #[test]
+    fn hidden_by_style_emits_medium_finding() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_with(false, false, true)];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn aria_hidden_takes_precedence_over_inert() {
+        // Both flags set — only the highest-priority finding is emitted.
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_with(true, true, true)];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].message.contains("aria-hidden"));
+    }
+
+    #[test]
+    fn start_step_is_ignored() {
+        let mut trace = trace_with(vec![]);
+        trace.steps.push(JourneyStep {
+            action: "start".to_string(),
+            target: None,
+            focus: Some("body".to_string()),
+            result: None,
+            snapshot_label: Some("initial".to_string()),
+        });
+        let snaps = vec![snap_with(true, false, false)];
+        assert!(tab_walk(&trace, &snaps).is_empty());
+    }
+}

--- a/src/a11y_journey/menu_journey.rs
+++ b/src/a11y_journey/menu_journey.rs
@@ -148,8 +148,7 @@ pub async fn test(
                 Keyboard users may not know the menu opened."
                 .to_string(),
             fix_suggestion: Some(
-                "Move focus to the first menu item after the menu opens."
-                    .to_string(),
+                "Move focus to the first menu item after the menu opens.".to_string(),
             ),
         });
     }

--- a/src/a11y_journey/menu_journey.rs
+++ b/src/a11y_journey/menu_journey.rs
@@ -1,0 +1,210 @@
+//! Menu journey: open menu trigger, verify focus moves, Escape closes.
+
+use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
+use chromiumoxide::Page;
+
+use crate::audit::normalized::{InteractiveFinding, JourneyStep, JourneyTrace};
+use crate::error::Result;
+use crate::interaction::{focus, keyboard, pointer, stability};
+use crate::patterns::JourneyCandidate;
+use crate::taxonomy::Severity;
+
+async fn eval_bool(page: &Page, js: &str) -> Option<bool> {
+    let params = EvaluateParams::builder()
+        .expression(js.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    result.result.result.value?.as_bool()
+}
+
+async fn eval_str(page: &Page, js: &str) -> Option<String> {
+    let params = EvaluateParams::builder()
+        .expression(js.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    let value = result.result.result.value?;
+    if value.is_null() {
+        None
+    } else {
+        value.as_str().map(|s| s.to_string())
+    }
+}
+
+pub async fn test(
+    page: &Page,
+    candidate: &JourneyCandidate,
+    index: usize,
+) -> Result<(JourneyTrace, Vec<InteractiveFinding>)> {
+    let journey_name = format!("menu_{index}");
+    let mut trace = JourneyTrace {
+        journey: journey_name.clone(),
+        steps: Vec::new(),
+    };
+    let mut findings: Vec<InteractiveFinding> = Vec::new();
+
+    let trigger_id = match candidate.trigger_backend_id {
+        Some(id) => id,
+        None => return Ok((trace, findings)),
+    };
+
+    // Capture aria-expanded before click.
+    let expanded_before = eval_str(
+        page,
+        "document.activeElement ? document.activeElement.getAttribute('aria-expanded') : null",
+    )
+    .await;
+
+    // Click trigger to open the menu.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("menu: click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_open_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    // Check menu expanded: look for aria-expanded="true" on any button, or a
+    // visible role="menu" element.
+    let menu_visible = eval_bool(
+        page,
+        "document.querySelector('[role=\"menu\"]') !== null || \
+         Array.from(document.querySelectorAll('[aria-expanded]')).some(function(e) { return e.getAttribute('aria-expanded') === 'true'; })",
+    )
+    .await
+    .unwrap_or(false);
+
+    trace.steps.push(JourneyStep {
+        action: "check_menu_open".to_string(),
+        target: None,
+        focus: None,
+        result: Some(if menu_visible {
+            "menu_open".to_string()
+        } else {
+            "menu_not_open".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !menu_visible {
+        findings.push(InteractiveFinding {
+            category: "MenuJourney".to_string(),
+            severity: Severity::Medium,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_open_click".to_string()),
+            message: "Menu trigger was clicked but menu did not open. \
+                Keyboard users cannot access menu items."
+                .to_string(),
+            fix_suggestion: Some(
+                "Set aria-expanded=\"true\" on the trigger and make the menu items visible \
+                when the trigger is activated."
+                    .to_string(),
+            ),
+        });
+        return Ok((trace, findings));
+    }
+
+    // Check focus moved into menu.
+    let focus_snap = focus::capture_focus(page).await?;
+    let focus_in_menu = eval_bool(
+        page,
+        "document.querySelector('[role=\"menu\"]')?.contains(document.activeElement) ?? false",
+    )
+    .await
+    .unwrap_or(false);
+
+    trace.steps.push(JourneyStep {
+        action: "check_focus_in_menu".to_string(),
+        target: None,
+        focus: focus_snap.selector.clone(),
+        result: Some(if focus_in_menu {
+            "focus_in_menu".to_string()
+        } else {
+            "focus_not_in_menu".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    // Focus in menu is recommended but not always enforced — emit as Info.
+    let _ = expanded_before; // unused for now
+    if !focus_in_menu {
+        findings.push(InteractiveFinding {
+            category: "MenuJourney".to_string(),
+            severity: Severity::Low,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_open_click".to_string()),
+            message: "After opening menu, focus did not move to menu items. \
+                Keyboard users may not know the menu opened."
+                .to_string(),
+            fix_suggestion: Some(
+                "Move focus to the first menu item after the menu opens."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // Press Escape and verify menu closes.
+    if let Err(e) = keyboard::press_escape(page).await {
+        tracing::warn!("menu: Escape press failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "escape".to_string(),
+        target: None,
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_escape".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    // Check menu is now closed.
+    let menu_closed = eval_bool(
+        page,
+        "document.querySelector('[role=\"menu\"]') === null && \
+         !Array.from(document.querySelectorAll('[aria-expanded]')).some(function(e) { return e.getAttribute('aria-expanded') === 'true'; })",
+    )
+    .await
+    .unwrap_or(true);
+
+    trace.steps.push(JourneyStep {
+        action: "check_menu_closed".to_string(),
+        target: None,
+        focus: None,
+        result: Some(if menu_closed {
+            "menu_closed".to_string()
+        } else {
+            "menu_still_open".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !menu_closed {
+        findings.push(InteractiveFinding {
+            category: "MenuJourney".to_string(),
+            severity: Severity::High,
+            journey: journey_name,
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_escape".to_string()),
+            message: "Escape key does not close the menu.".to_string(),
+            fix_suggestion: Some(
+                "Add a keydown handler that closes the menu and returns focus to the trigger \
+                when Escape is pressed."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok((trace, findings))
+}

--- a/src/a11y_journey/mod.rs
+++ b/src/a11y_journey/mod.rs
@@ -84,9 +84,7 @@ pub async fn run(ctx: RunContext<'_>) -> Result<Option<RunOutput>> {
 
         for candidate in &patterns.journey_candidates {
             if Instant::now() >= deadline {
-                tracing::info!(
-                    "Journey budget exhausted, stopping pattern journeys early."
-                );
+                tracing::info!("Journey budget exhausted, stopping pattern journeys early.");
                 break;
             }
             if candidate.confidence < 0.7 {
@@ -131,11 +129,7 @@ pub async fn run(ctx: RunContext<'_>) -> Result<Option<RunOutput>> {
                     out.findings.extend(findings);
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Journey {:?} failed: {}",
-                        candidate.required_journey,
-                        e
-                    );
+                    tracing::warn!("Journey {:?} failed: {}", candidate.required_journey, e);
                 }
             }
         }

--- a/src/a11y_journey/mod.rs
+++ b/src/a11y_journey/mod.rs
@@ -1,24 +1,27 @@
 //! Accessibility-Journey-Layer — runs interactive journeys against a page
 //! after the static AXTree-based audit has finished.
 //!
-//! Phase 1: foundation only.
-//! - `RunContext` defines the data the orchestrator needs.
-//! - `run()` is the **single** pipeline hook; Phase 2-5 extend its body
-//!   without changing the signature.
-//! - `tab_walk` produces a reproducible focus sequence trace, but does not
-//!   yet emit findings.
+//! `run()` is the **single** pipeline hook; phases 2–5 extend its body
+//! without changing the signature.
 //!
-//! Higher-level evaluation (`FocusTrap`, `SpaNavigation`, `FormError`, …)
-//! lands in Phase 2-3.
+//! Phase 2: tab-walk evaluation, skip-link, disclosure, modal, tabs, menu journeys.
 
+pub mod disclosure_journey;
+pub mod evaluate;
+pub mod menu_journey;
+pub mod modal_journey;
+pub mod skip_link;
 pub mod tab_walk;
+pub mod tabs_journey;
+
+use std::time::Instant;
 
 use chromiumoxide::Page;
 
-use crate::audit::normalized::AccessibilityJourney;
+use crate::audit::normalized::{AccessibilityJourney, InteractiveFinding};
 use crate::cli::InteractiveMode;
 use crate::error::Result;
-use crate::patterns::PatternAnalysis;
+use crate::patterns::{JourneyKind, PatternAnalysis};
 
 /// Inputs the journey orchestrator needs. Kept narrow on purpose so the
 /// pipeline only has to pass what is actually used.
@@ -33,29 +36,110 @@ pub struct RunContext<'a> {
     pub budget_ms: u64,
 }
 
+/// Output of one journey run. The trace bundle and findings are kept
+/// separate so the caller can route them to the right slots on
+/// `AuditReport` / `NormalizedReport` (`accessibility_journey` vs.
+/// `interactive_findings`).
+#[derive(Default)]
+pub struct RunOutput {
+    pub journey: AccessibilityJourney,
+    pub findings: Vec<InteractiveFinding>,
+}
+
 /// Default journey budget per URL (ms).
 pub const DEFAULT_BUDGET_MS: u64 = 5000;
 
 /// Single entry point invoked from `audit/pipeline.rs::audit_page`.
 ///
-/// Returns `None` for `--interactive=off` so the rest of the pipeline pays
-/// zero cost. Otherwise dispatches the configured set of journeys and
-/// produces an `AccessibilityJourney` with at least one trace.
-pub async fn run(ctx: RunContext<'_>) -> Result<Option<AccessibilityJourney>> {
+/// Returns `None` for `--interactive=off` so the rest of the pipeline
+/// pays zero cost. Otherwise records journeys, evaluates them, and
+/// returns both pieces.
+pub async fn run(ctx: RunContext<'_>) -> Result<Option<RunOutput>> {
     if !ctx.mode.is_enabled() {
         return Ok(None);
     }
 
-    let mut journey = AccessibilityJourney::default();
+    let deadline = Instant::now() + std::time::Duration::from_millis(ctx.budget_ms);
+    let mut out = RunOutput::default();
 
-    // Phase 1: tab walk only (no evaluation, just a recorded trace).
     let max_steps = match ctx.mode {
         InteractiveMode::Off => 0,
         InteractiveMode::Basic => 25,
         InteractiveMode::Full => 60,
     };
-    let trace = tab_walk::record(ctx.page, max_steps).await?;
-    journey.traces.push(trace);
 
-    Ok(Some(journey))
+    // Tab walk + evaluation.
+    let record = tab_walk::record(ctx.page, max_steps).await?;
+    out.findings
+        .extend(evaluate::tab_walk(&record.trace, &record.snapshots));
+    out.journey.traces.push(record.trace);
+
+    // Pattern-based journeys — only if we have candidates and time remains.
+    if let Some(patterns) = ctx.patterns {
+        let mut skip_link_idx = 0usize;
+        let mut disclosure_idx = 0usize;
+        let mut modal_idx = 0usize;
+        let mut tabs_idx = 0usize;
+        let mut menu_idx = 0usize;
+
+        for candidate in &patterns.journey_candidates {
+            if Instant::now() >= deadline {
+                tracing::info!(
+                    "Journey budget exhausted, stopping pattern journeys early."
+                );
+                break;
+            }
+            if candidate.confidence < 0.7 {
+                continue;
+            }
+
+            let result = match candidate.required_journey {
+                JourneyKind::SkipLinkActivate => {
+                    let idx = skip_link_idx;
+                    skip_link_idx += 1;
+                    skip_link::test(ctx.page, candidate, idx).await
+                }
+                JourneyKind::DisclosureToggle | JourneyKind::AccordionToggle => {
+                    let idx = disclosure_idx;
+                    disclosure_idx += 1;
+                    disclosure_journey::test(ctx.page, candidate, idx).await
+                }
+                JourneyKind::ModalOpen => {
+                    let idx = modal_idx;
+                    modal_idx += 1;
+                    modal_journey::test(ctx.page, candidate, idx).await
+                }
+                JourneyKind::TabsNavigate => {
+                    let idx = tabs_idx;
+                    tabs_idx += 1;
+                    tabs_journey::test(ctx.page, candidate, idx).await
+                }
+                JourneyKind::MenuOpen => {
+                    let idx = menu_idx;
+                    menu_idx += 1;
+                    menu_journey::test(ctx.page, candidate, idx).await
+                }
+                JourneyKind::FormErrorSubmit => {
+                    // Phase 3.
+                    continue;
+                }
+            };
+
+            match result {
+                Ok((trace, findings)) => {
+                    out.journey.traces.push(trace);
+                    out.findings.extend(findings);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Journey {:?} failed: {}",
+                        candidate.required_journey,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(Some(out))
 }

--- a/src/a11y_journey/modal_journey.rs
+++ b/src/a11y_journey/modal_journey.rs
@@ -109,8 +109,9 @@ pub async fn test(
             journey: journey_name.clone(),
             before_snapshot_label: None,
             after_snapshot_label: Some("after_open_click".to_string()),
-            message: "Background content is not hidden from assistive technology when modal is open."
-                .to_string(),
+            message:
+                "Background content is not hidden from assistive technology when modal is open."
+                    .to_string(),
             fix_suggestion: Some(
                 "Set aria-hidden=\"true\" on the application root when a modal is open, \
                 or use the inert attribute."
@@ -266,4 +267,3 @@ pub async fn test(
 
     Ok((trace, findings))
 }
-

--- a/src/a11y_journey/modal_journey.rs
+++ b/src/a11y_journey/modal_journey.rs
@@ -1,0 +1,269 @@
+//! Modal journey: open dialog, verify focus trap, Escape closes, focus restores.
+
+use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
+use chromiumoxide::Page;
+
+use crate::audit::normalized::{InteractiveFinding, JourneyStep, JourneyTrace};
+use crate::error::Result;
+use crate::interaction::{focus, keyboard, pointer, stability};
+use crate::patterns::JourneyCandidate;
+use crate::taxonomy::Severity;
+
+async fn eval_bool(page: &Page, js: &str) -> Option<bool> {
+    let params = EvaluateParams::builder()
+        .expression(js.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    result.result.result.value?.as_bool()
+}
+
+pub async fn test(
+    page: &Page,
+    candidate: &JourneyCandidate,
+    index: usize,
+) -> Result<(JourneyTrace, Vec<InteractiveFinding>)> {
+    let journey_name = format!("modal_{index}");
+    let mut trace = JourneyTrace {
+        journey: journey_name.clone(),
+        steps: Vec::new(),
+    };
+    let mut findings: Vec<InteractiveFinding> = Vec::new();
+
+    let trigger_id = match candidate.trigger_backend_id {
+        Some(id) => id,
+        None => return Ok((trace, findings)),
+    };
+
+    // Capture focus before opening (for restoration check later).
+    let trigger_snap = focus::capture_focus(page).await?;
+    let trigger_selector = trigger_snap.selector.clone();
+
+    // Click trigger to open the modal.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("modal: click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_open_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    // 1. Check focus moved inside dialog.
+    let focus_in_dialog = eval_bool(
+        page,
+        "document.querySelector('[role=\"dialog\"],[role=\"alertdialog\"]')?.contains(document.activeElement) ?? false",
+    )
+    .await
+    .unwrap_or(false);
+
+    let focus_snap = focus::capture_focus(page).await?;
+    trace.steps.push(JourneyStep {
+        action: "check_focus_in_dialog".to_string(),
+        target: None,
+        focus: focus_snap.selector.clone(),
+        result: Some(if focus_in_dialog {
+            "focus_inside_dialog".to_string()
+        } else {
+            "focus_not_in_dialog".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !focus_in_dialog {
+        findings.push(InteractiveFinding {
+            category: "FocusTrap".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_open_click".to_string()),
+            message: "After opening modal, focus did not move inside the dialog. \
+                Keyboard users cannot interact with it."
+                .to_string(),
+            fix_suggestion: Some(
+                "Move focus to the first focusable element inside the dialog when it opens, \
+                or to the dialog element itself (tabindex=\"-1\")."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // 2. Check background is inert/aria-hidden.
+    let background_hidden = eval_bool(
+        page,
+        "document.querySelector('[aria-hidden=\"true\"]') !== null",
+    )
+    .await
+    .unwrap_or(true); // If we can't read, don't emit a false positive.
+
+    if !background_hidden {
+        findings.push(InteractiveFinding {
+            category: "FocusTrap".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_open_click".to_string()),
+            message: "Background content is not hidden from assistive technology when modal is open."
+                .to_string(),
+            fix_suggestion: Some(
+                "Set aria-hidden=\"true\" on the application root when a modal is open, \
+                or use the inert attribute."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // 3. Focus trap check: press Tab 3 times, verify focus stays in dialog.
+    let mut focus_escaped = false;
+    for i in 0..3 {
+        if let Err(e) = keyboard::press_tab(page).await {
+            tracing::warn!("modal: Tab press {i} failed: {e}");
+            break;
+        }
+        stability::settle(page).await?;
+
+        let still_in = eval_bool(
+            page,
+            "document.querySelector('[role=\"dialog\"],[role=\"alertdialog\"]')?.contains(document.activeElement) ?? false",
+        )
+        .await
+        .unwrap_or(true);
+
+        let tab_snap = focus::capture_focus(page).await?;
+        trace.steps.push(JourneyStep {
+            action: "tab".to_string(),
+            target: None,
+            focus: tab_snap.selector.clone(),
+            result: Some(if still_in {
+                "focus_in_dialog".to_string()
+            } else {
+                "focus_escaped".to_string()
+            }),
+            snapshot_label: None,
+        });
+
+        if !still_in {
+            focus_escaped = true;
+            break;
+        }
+    }
+
+    if focus_escaped {
+        findings.push(InteractiveFinding {
+            category: "FocusTrap".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: None,
+            message: "Focus is not trapped inside the modal dialog. \
+                Keyboard users can navigate to background content."
+                .to_string(),
+            fix_suggestion: Some(
+                "Intercept Tab and Shift+Tab inside the dialog to cycle focus among \
+                dialog descendants only."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // 4. Press Escape and check modal closes.
+    if let Err(e) = keyboard::press_escape(page).await {
+        tracing::warn!("modal: Escape press failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "escape".to_string(),
+        target: None,
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_escape".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    let dialog_closed = eval_bool(
+        page,
+        "document.querySelector('[role=\"dialog\"],[role=\"alertdialog\"]') === null || \
+         document.querySelector('[role=\"dialog\"],[role=\"alertdialog\"]')?.getAttribute('aria-hidden') === 'true'",
+    )
+    .await
+    .unwrap_or(true);
+
+    trace.steps.push(JourneyStep {
+        action: "check_dialog_closed".to_string(),
+        target: None,
+        focus: None,
+        result: Some(if dialog_closed {
+            "dialog_closed".to_string()
+        } else {
+            "dialog_still_open".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !dialog_closed {
+        findings.push(InteractiveFinding {
+            category: "FocusTrap".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_escape".to_string()),
+            message: "Escape key does not close the modal. Keyboard users cannot dismiss it."
+                .to_string(),
+            fix_suggestion: Some(
+                "Add a keydown handler on the dialog or document that calls close() \
+                or hides the dialog when Escape is pressed."
+                    .to_string(),
+            ),
+        });
+        return Ok((trace, findings));
+    }
+
+    // 5. Focus restoration: focus should return to trigger, not body.
+    let after_close_snap = focus::capture_focus(page).await?;
+    let focus_after = after_close_snap.selector.clone();
+
+    trace.steps.push(JourneyStep {
+        action: "check_focus_restored".to_string(),
+        target: trigger_selector.clone(),
+        focus: focus_after.clone(),
+        result: None,
+        snapshot_label: Some("after_escape".to_string()),
+    });
+
+    let focus_on_body = focus_after.is_none()
+        || focus_after
+            .as_deref()
+            .map(|s| {
+                let low = s.to_lowercase();
+                low == "body" || low == "html"
+            })
+            .unwrap_or(false);
+
+    if focus_on_body {
+        findings.push(InteractiveFinding {
+            category: "FocusRestoration".to_string(),
+            severity: Severity::Medium,
+            journey: journey_name,
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_escape".to_string()),
+            message: "After closing the modal, focus returned to body instead of the trigger. \
+                Keyboard users lose their place on the page."
+                .to_string(),
+            fix_suggestion: Some(
+                "Store a reference to the trigger element before opening the dialog and \
+                call trigger.focus() when the dialog closes."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok((trace, findings))
+}
+

--- a/src/a11y_journey/skip_link.rs
+++ b/src/a11y_journey/skip_link.rs
@@ -1,0 +1,88 @@
+//! Skip-link journey: activate a skip link and verify focus moves to target.
+
+use chromiumoxide::Page;
+
+use crate::audit::normalized::{InteractiveFinding, JourneyStep, JourneyTrace};
+use crate::error::Result;
+use crate::interaction::{focus, pointer, stability};
+use crate::patterns::JourneyCandidate;
+use crate::taxonomy::Severity;
+
+pub async fn test(
+    page: &Page,
+    candidate: &JourneyCandidate,
+    index: usize,
+) -> Result<(JourneyTrace, Vec<InteractiveFinding>)> {
+    let journey_name = format!("skip_link_{index}");
+    let mut trace = JourneyTrace {
+        journey: journey_name.clone(),
+        steps: Vec::new(),
+    };
+    let mut findings: Vec<InteractiveFinding> = Vec::new();
+
+    let trigger_id = match candidate.trigger_backend_id {
+        Some(id) => id,
+        None => return Ok((trace, findings)),
+    };
+
+    // Activate the skip link via synthetic click.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("skip_link: click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_skip_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    // Capture focus after activation.
+    let snap = focus::capture_focus(page).await?;
+    let focus_selector = snap.selector.clone();
+
+    // Determine if focus actually moved to a meaningful target.
+    let focus_on_body = focus_selector.is_none()
+        || focus_selector
+            .as_deref()
+            .map(|s| {
+                let low = s.to_lowercase();
+                low == "body" || low == "html"
+            })
+            .unwrap_or(false);
+
+    trace.steps.push(JourneyStep {
+        action: "check_focus".to_string(),
+        target: None,
+        focus: focus_selector.clone(),
+        result: Some(if focus_on_body {
+            "focus_not_moved".to_string()
+        } else {
+            "focus_moved".to_string()
+        }),
+        snapshot_label: Some("after_skip_link".to_string()),
+    });
+
+    if focus_on_body {
+        findings.push(InteractiveFinding {
+            category: "SkipLink".to_string(),
+            severity: Severity::High,
+            journey: journey_name,
+            before_snapshot_label: None,
+            after_snapshot_label: Some("after_skip_link".to_string()),
+            message: "Skip link is present but does not move focus to the target. \
+                Keyboard users cannot bypass navigation."
+                .to_string(),
+            fix_suggestion: Some(
+                "Ensure the skip link target has tabindex=\"-1\" and receives focus via \
+                an anchor link, or explicitly call target.focus() after navigation."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok((trace, findings))
+}

--- a/src/a11y_journey/tab_walk.rs
+++ b/src/a11y_journey/tab_walk.rs
@@ -1,25 +1,36 @@
 //! Tab-walk journey: press Tab N times and record where focus ends up.
 //!
-//! Phase 1 captures the sequence as a `JourneyTrace`. No evaluation — that
-//! lands in Phase 2 (out-of-order detection, hidden focusables, focus
-//! indicator status).
+//! Records a reproducible `JourneyTrace` along with the per-step
+//! `FocusSnapshot`s. The trace is the evidence; `evaluate::tab_walk()`
+//! turns it into `InteractiveFinding`s.
 
 use chromiumoxide::Page;
 
+use crate::accessibility::FocusSnapshot;
 use crate::audit::normalized::{JourneyStep, JourneyTrace};
 use crate::error::Result;
 use crate::interaction::{focus, keyboard, stability};
 
+/// Record of one tab-walk run: the trace plus the rich `FocusSnapshot`
+/// per step. Snapshots are kept alongside (not embedded in the trace)
+/// so the JSON output stays compact.
+pub struct TabWalkRecord {
+    pub trace: JourneyTrace,
+    /// `snapshots[i]` corresponds to `trace.steps[i]`.
+    pub snapshots: Vec<FocusSnapshot>,
+}
+
 /// Record a tab walk of up to `max_steps` Tab presses.
 ///
 /// Stops early when focus stops changing (loop or trap detected) or when
-/// no focusable element remains. The returned trace is *evidence only*;
-/// any findings are derived from it in later phases.
-pub async fn record(page: &Page, max_steps: usize) -> Result<JourneyTrace> {
+/// no focusable element remains. The returned record is *evidence only*;
+/// findings come from the evaluator.
+pub async fn record(page: &Page, max_steps: usize) -> Result<TabWalkRecord> {
     let mut trace = JourneyTrace {
         journey: "tab_walk".to_string(),
         steps: Vec::with_capacity(max_steps),
     };
+    let mut snapshots: Vec<FocusSnapshot> = Vec::with_capacity(max_steps);
 
     // Initial focus snapshot — usually body / no element.
     let start = focus::capture_focus(page).await?;
@@ -30,8 +41,8 @@ pub async fn record(page: &Page, max_steps: usize) -> Result<JourneyTrace> {
         result: None,
         snapshot_label: Some("initial".to_string()),
     });
-
-    let mut last_focus_selector = start.selector;
+    let mut last_focus_selector = start.selector.clone();
+    snapshots.push(start);
 
     for i in 0..max_steps {
         keyboard::press_tab(page).await?;
@@ -57,6 +68,7 @@ pub async fn record(page: &Page, max_steps: usize) -> Result<JourneyTrace> {
             result,
             snapshot_label: Some(format!("after_tab_{}", i + 1)),
         });
+        snapshots.push(snap);
 
         if stuck {
             break;
@@ -64,5 +76,5 @@ pub async fn record(page: &Page, max_steps: usize) -> Result<JourneyTrace> {
         last_focus_selector = current;
     }
 
-    Ok(trace)
+    Ok(TabWalkRecord { trace, snapshots })
 }

--- a/src/a11y_journey/tabs_journey.rs
+++ b/src/a11y_journey/tabs_journey.rs
@@ -1,0 +1,158 @@
+//! Tabs journey: click first tab, verify ArrowRight moves selection.
+
+use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
+use chromiumoxide::Page;
+
+use crate::audit::normalized::{InteractiveFinding, JourneyStep, JourneyTrace};
+use crate::error::Result;
+use crate::interaction::{focus, keyboard, pointer, stability};
+use crate::patterns::JourneyCandidate;
+use crate::taxonomy::Severity;
+
+/// Collect `aria-selected` values for all `[role="tab"]` elements.
+const COLLECT_TABS_JS: &str = r#"
+(function() {
+    var tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+    return tabs.map(function(t) { return t.getAttribute('aria-selected'); });
+})()
+"#;
+
+async fn collect_tab_states(page: &Page) -> Option<Vec<Option<String>>> {
+    let params = EvaluateParams::builder()
+        .expression(COLLECT_TABS_JS.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    let value = result.result.result.value?;
+    let arr = value.as_array()?;
+    Some(
+        arr.iter()
+            .map(|v| {
+                if v.is_null() {
+                    None
+                } else {
+                    v.as_str().map(|s| s.to_string())
+                }
+            })
+            .collect(),
+    )
+}
+
+pub async fn test(
+    page: &Page,
+    candidate: &JourneyCandidate,
+    index: usize,
+) -> Result<(JourneyTrace, Vec<InteractiveFinding>)> {
+    let journey_name = format!("tabs_{index}");
+    let mut trace = JourneyTrace {
+        journey: journey_name.clone(),
+        steps: Vec::new(),
+    };
+    let mut findings: Vec<InteractiveFinding> = Vec::new();
+
+    let trigger_id = match candidate.trigger_backend_id {
+        Some(id) => id,
+        None => return Ok((trace, findings)),
+    };
+
+    // Click the first tab.
+    if let Err(e) = pointer::synthetic_click_backend(page, trigger_id).await {
+        tracing::warn!("tabs: click on backend node {trigger_id} failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "synthetic_click".to_string(),
+        target: Some(format!("backend_node:{trigger_id}")),
+        focus: None,
+        result: None,
+        snapshot_label: Some("after_first_tab_click".to_string()),
+    });
+
+    stability::settle(page).await?;
+
+    let states_after_click = collect_tab_states(page).await;
+
+    // Press ArrowRight to navigate to second tab.
+    if let Err(e) = keyboard::press_arrow(page, "Right").await {
+        tracing::warn!("tabs: ArrowRight failed: {e}");
+        return Ok((trace, findings));
+    }
+    trace.steps.push(JourneyStep {
+        action: "arrow_right".to_string(),
+        target: None,
+        focus: None,
+        result: None,
+        snapshot_label: None,
+    });
+
+    stability::settle(page).await?;
+
+    let states_after_arrow = collect_tab_states(page).await;
+    let focus_snap = focus::capture_focus(page).await?;
+
+    // Check: aria-selected changed for at least one tab.
+    let selection_moved = match (&states_after_click, &states_after_arrow) {
+        (Some(before), Some(after)) => before != after,
+        _ => true, // Can't determine, don't emit false positive.
+    };
+
+    trace.steps.push(JourneyStep {
+        action: "check_selection".to_string(),
+        target: None,
+        focus: focus_snap.selector.clone(),
+        result: Some(if selection_moved {
+            "selection_moved".to_string()
+        } else {
+            "selection_unchanged".to_string()
+        }),
+        snapshot_label: None,
+    });
+
+    if !selection_moved {
+        findings.push(InteractiveFinding {
+            category: "TabsJourney".to_string(),
+            severity: Severity::High,
+            journey: journey_name.clone(),
+            before_snapshot_label: Some("after_first_tab_click".to_string()),
+            after_snapshot_label: None,
+            message: "Arrow key navigation does not move selection between tabs. \
+                Keyboard users cannot navigate the tab list."
+                .to_string(),
+            fix_suggestion: Some(
+                "Implement the roving tabindex pattern: ArrowRight moves focus and \
+                aria-selected to the next tab."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // Check: focus is on a tab element after the arrow key press.
+    let focus_on_tab = focus_snap
+        .selector
+        .as_deref()
+        .map(|s| {
+            // Heuristic: if we can read focus and it's not body, assume it's on a tab.
+            !s.to_lowercase().contains("body")
+        })
+        .unwrap_or(false);
+
+    if !focus_on_tab {
+        findings.push(InteractiveFinding {
+            category: "TabsJourney".to_string(),
+            severity: Severity::Medium,
+            journey: journey_name,
+            before_snapshot_label: None,
+            after_snapshot_label: None,
+            message: "After pressing ArrowRight in the tab list, focus is not on a tab element."
+                .to_string(),
+            fix_suggestion: Some(
+                "Ensure arrow key navigation also moves focus (not just selection) \
+                to the next tab in the roving tabindex pattern."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok((trace, findings))
+}

--- a/src/accessibility/diff.rs
+++ b/src/accessibility/diff.rs
@@ -46,9 +46,12 @@ pub struct FocusMove {
     pub after: Option<i64>,
 }
 
+/// ARIA state properties tracked for property-level diffs.
+const TRACKED_PROPERTIES: &[&str] = &["expanded", "hidden", "selected", "invalid", "modal"];
+
 impl AXTreeDiff {
     /// Compute the structural diff between two snapshots.
-    /// Phase 1: identity, focus, title, URL. Property-level diffing is Phase 2.
+    /// Phase 2: adds property-level diffing for key ARIA state properties.
     pub fn between(before: &AXSnapshot, after: &AXSnapshot) -> Self {
         let mut diff = AXTreeDiff::default();
 
@@ -78,6 +81,28 @@ impl AXTreeDiff {
         }
         diff.added.sort();
         diff.removed.sort();
+
+        // Property-level diffing: track meaningful ARIA state changes.
+        for (node_id, after_node) in &after.tree.nodes {
+            if let Some(before_node) = before.tree.nodes.get(node_id) {
+                for prop_name in TRACKED_PROPERTIES {
+                    let before_val = before_node.get_property_bool(prop_name);
+                    let after_val = after_node.get_property_bool(prop_name);
+                    if before_val != after_val {
+                        diff.property_changes.push(PropertyChange {
+                            node_id: node_id.clone(),
+                            property: prop_name.to_string(),
+                            before: before_val
+                                .map(|b| b.to_string())
+                                .unwrap_or_default(),
+                            after: after_val
+                                .map(|b| b.to_string())
+                                .unwrap_or_default(),
+                        });
+                    }
+                }
+            }
+        }
 
         diff
     }

--- a/src/accessibility/diff.rs
+++ b/src/accessibility/diff.rs
@@ -92,12 +92,8 @@ impl AXTreeDiff {
                         diff.property_changes.push(PropertyChange {
                             node_id: node_id.clone(),
                             property: prop_name.to_string(),
-                            before: before_val
-                                .map(|b| b.to_string())
-                                .unwrap_or_default(),
-                            after: after_val
-                                .map(|b| b.to_string())
-                                .unwrap_or_default(),
+                            before: before_val.map(|b| b.to_string()).unwrap_or_default(),
+                            after: after_val.map(|b| b.to_string()).unwrap_or_default(),
                         });
                     }
                 }

--- a/src/accessibility/snapshot.rs
+++ b/src/accessibility/snapshot.rs
@@ -53,6 +53,19 @@ pub struct FocusSnapshot {
     pub bounding_box: Option<Rect>,
     /// Selector of an overlay occluding the focused element, if any.
     pub obscured_by: Option<String>,
+    /// Some ancestor (or the element itself) has `aria-hidden="true"`.
+    /// Focus landing here is a clear accessibility violation.
+    #[serde(default)]
+    pub aria_hidden_chain: bool,
+    /// Some ancestor (or the element itself) has the `inert` attribute.
+    /// Focus landing here is a clear accessibility violation.
+    #[serde(default)]
+    pub inert_chain: bool,
+    /// Computed style hides the element (`display:none`, `visibility:hidden`,
+    /// or `opacity:0`). Usually a sign of a focusable element that should
+    /// have been removed from the tab sequence.
+    #[serde(default)]
+    pub hidden_by_style: bool,
 }
 
 /// Detection of a visible focus indicator.

--- a/src/ai_visibility/mod.rs
+++ b/src/ai_visibility/mod.rs
@@ -749,6 +749,7 @@ mod tests {
             consent_banner_cmp: None,
             consent_banner_dismissed: false,
             accessibility_journey: None,
+            interactive_findings: Vec::new(),
         }
     }
 

--- a/src/audit/artifacts.rs
+++ b/src/audit/artifacts.rs
@@ -265,6 +265,7 @@ pub fn to_audit_report(artifacts: &AuditArtifacts) -> AuditReport {
         consent_banner_cmp: None,
         consent_banner_dismissed: false,
         accessibility_journey: None,
+        interactive_findings: Vec::new(),
     };
 
     if report.wcag_level != artifacts.audit.wcag_level {

--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -1217,9 +1217,9 @@ pub fn normalize(report: &AuditReport) -> NormalizedReport {
         viewport_scores: report.viewport_scores.clone(),
         score_calculation_method,
         score_breakdown,
-        // Accessibility-Journey-Layer — Phase 1 carries the trace through;
-        // findings/advisories are populated starting with Phase 2.
-        interactive_findings: Vec::new(),
+        // Accessibility-Journey-Layer — Phase 2a populates findings;
+        // advisories remain stubbed until Phase 4 wires up the LLM layer.
+        interactive_findings: report.interactive_findings.clone(),
         accessibility_journey: report.accessibility_journey.clone(),
         advisory_findings: Vec::new(),
         raw_performance: report.performance.clone(),

--- a/src/audit/pipeline.rs
+++ b/src/audit/pipeline.rs
@@ -467,7 +467,11 @@ pub async fn audit_page(
         budget_ms: crate::a11y_journey::DEFAULT_BUDGET_MS,
     };
     match crate::a11y_journey::run(journey_ctx).await {
-        Ok(journey) => report.accessibility_journey = journey,
+        Ok(Some(out)) => {
+            report.accessibility_journey = Some(out.journey);
+            report.interactive_findings = out.findings;
+        }
+        Ok(None) => {}
         Err(e) => warn!("Accessibility-Journey-Layer failed: {}", e),
     }
 

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -199,6 +199,10 @@ pub struct AuditReport {
     /// Accessibility-Journey-Layer result (populated when `--interactive != off`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility_journey: Option<crate::audit::normalized::AccessibilityJourney>,
+    /// Interactive findings produced by the Accessibility-Journey-Layer
+    /// evaluator. Empty when `--interactive=off`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub interactive_findings: Vec<crate::audit::normalized::InteractiveFinding>,
 }
 
 /// Performance analysis results wrapper
@@ -284,6 +288,7 @@ impl AuditReport {
             consent_banner_cmp: None,
             consent_banner_dismissed: false,
             accessibility_journey: None,
+            interactive_findings: Vec::new(),
         }
     }
 

--- a/src/interaction/focus.rs
+++ b/src/interaction/focus.rs
@@ -176,7 +176,7 @@ pub async fn capture_focus(page: &Page) -> Result<FocusSnapshot> {
         .unwrap_or(false);
 
     // visible = element has non-zero box and is not hidden by style.
-    let has_area = bbox.map_or(false, |b| b.width > 0.0 && b.height > 0.0);
+    let has_area = bbox.is_some_and(|b| b.width > 0.0 && b.height > 0.0);
     let visible = has_area && !hidden_by_style;
 
     let focus_indicator = detect_focus_indicator(page).await;

--- a/src/interaction/focus.rs
+++ b/src/interaction/focus.rs
@@ -1,22 +1,18 @@
 //! Focus tracking utilities.
 //!
 //! Builds the `FocusSnapshot` that accompanies each `AXSnapshot` in a
-//! journey. Phase 1 wires up the basics: `document.activeElement` selector
-//! and bounding-box. Visibility, indicator detection (`Detected`/
-//! `NotDetected`/`Ambiguous`) and overlay-occlusion checks land in Phase 2.
+//! journey. Phase 2 adds focus-indicator detection via computed style.
 
 use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
 use chromiumoxide::Page;
 use serde_json::Value;
 
-use crate::accessibility::{FocusSnapshot, Rect};
+use crate::accessibility::{FocusIndicatorStatus, FocusSnapshot, Rect};
 use crate::error::{AuditError, Result};
 
-/// JS that returns a minimal description of `document.activeElement`.
-///
-/// Returns `{ selector, x, y, w, h, hasFocus }` or `null` when no element
-/// has focus (or only `document.body` does — which we treat as "no focus"
-/// for journey purposes).
+/// JS that returns a description of `document.activeElement`, including
+/// visibility flags used by the journey evaluator. `null` when no element
+/// has focus (or only body/documentElement, which we treat as "no focus").
 const ACTIVE_ELEMENT_JS: &str = r#"
 (function () {
     var el = document.activeElement;
@@ -24,6 +20,8 @@ const ACTIVE_ELEMENT_JS: &str = r#"
         return null;
     }
     var rect = el.getBoundingClientRect();
+    var vw = window.innerWidth || document.documentElement.clientWidth;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
     function selectorFor(node) {
         if (!node || node.nodeType !== 1) return null;
         if (node.id) return '#' + node.id;
@@ -46,18 +44,76 @@ const ACTIVE_ELEMENT_JS: &str = r#"
         }
         return parts.join(' > ');
     }
+    // Ancestor-chain checks: a focused element is "hidden" if anywhere on
+    // the path to <html> there is aria-hidden="true" or an inert attribute.
+    var ariaHiddenChain = false;
+    var inertChain = false;
+    var n = el;
+    while (n && n.nodeType === 1) {
+        if (n.getAttribute) {
+            if (n.getAttribute('aria-hidden') === 'true') ariaHiddenChain = true;
+            if (n.hasAttribute('inert')) inertChain = true;
+        }
+        n = n.parentNode;
+    }
+    var style = window.getComputedStyle(el);
+    var hiddenByStyle =
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        parseFloat(style.opacity) === 0;
+    var inViewport = rect.right > 0 && rect.bottom > 0 && rect.left < vw && rect.top < vh;
     return {
         selector: selectorFor(el),
         x: rect.x, y: rect.y, w: rect.width, h: rect.height,
+        ariaHiddenChain: ariaHiddenChain,
+        inertChain: inertChain,
+        hiddenByStyle: hiddenByStyle,
+        inViewport: inViewport,
     };
 })()
 "#;
 
+/// JS that checks whether the currently focused element has a visible focus
+/// indicator via outline, box-shadow, or border changes.
+const FOCUS_INDICATOR_JS: &str = r#"
+(function() {
+    var el = document.activeElement;
+    if (!el || el === document.body || el === document.documentElement) return 'ambiguous';
+    var cs = window.getComputedStyle(el);
+    var outlineStyle = cs.outlineStyle;
+    var outlineWidth = cs.outlineWidth;
+    var boxShadow = cs.boxShadow;
+    var hasOutline = outlineStyle !== 'none' && outlineWidth !== '0px';
+    var hasBoxShadow = boxShadow !== 'none';
+    if (hasOutline || hasBoxShadow) return 'detected';
+    var borderWidth = cs.borderWidth;
+    if (borderWidth !== '0px') return 'ambiguous';
+    return 'not_detected';
+})()
+"#;
+
+/// Detect whether the currently focused element has a visible focus indicator.
+///
+/// Returns `None` if the evaluation fails (e.g. page navigating or no focus).
+pub async fn detect_focus_indicator(page: &Page) -> Option<FocusIndicatorStatus> {
+    let params = EvaluateParams::builder()
+        .expression(FOCUS_INDICATOR_JS.to_string())
+        .return_by_value(true)
+        .build()
+        .ok()?;
+    let result = page.execute(params).await.ok()?;
+    let value = result.result.result.value?;
+    let s = value.as_str()?;
+    Some(match s {
+        "detected" => FocusIndicatorStatus::Detected,
+        "not_detected" => FocusIndicatorStatus::NotDetected,
+        _ => FocusIndicatorStatus::Ambiguous,
+    })
+}
+
 /// Build a `FocusSnapshot` from the current page state.
 ///
-/// Phase 1 fills `selector` and `bounding_box`; backend-node mapping and
-/// viewport intersection are also evaluated. Indicator detection is left
-/// as `None` for Phase 2.
+/// Fills selector, bounding_box, visibility flags, and focus-indicator status.
 pub async fn capture_focus(page: &Page) -> Result<FocusSnapshot> {
     let params = EvaluateParams::builder()
         .expression(ACTIVE_ELEMENT_JS.to_string())
@@ -102,15 +158,40 @@ pub async fn capture_focus(page: &Page) -> Result<FocusSnapshot> {
         }),
         _ => None,
     };
+    let aria_hidden_chain = value
+        .get("ariaHiddenChain")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let inert_chain = value
+        .get("inertChain")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let hidden_by_style = value
+        .get("hiddenByStyle")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let in_viewport = value
+        .get("inViewport")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    // visible = element has non-zero box and is not hidden by style.
+    let has_area = bbox.map_or(false, |b| b.width > 0.0 && b.height > 0.0);
+    let visible = has_area && !hidden_by_style;
+
+    let focus_indicator = detect_focus_indicator(page).await;
 
     Ok(FocusSnapshot {
         active_backend_node_id: None,
         ax_node_id: None,
         selector,
-        visible: bbox.is_some(),
-        in_viewport: bbox.is_some(),
-        focus_indicator: None,
+        visible,
+        in_viewport,
+        focus_indicator,
         bounding_box: bbox,
         obscured_by: None,
+        aria_hidden_chain,
+        inert_chain,
+        hidden_by_style,
     })
 }

--- a/src/interaction/stability.rs
+++ b/src/interaction/stability.rs
@@ -1,26 +1,36 @@
 //! Wait for the page to settle after an interaction.
 //!
-//! Phase 1: a pragmatic fixed pause that the journey orchestrator can call
-//! after each action. Phase 2 replaces this with DOM + AXTree quiescence
-//! detection (MutationObserver settle window).
-//!
-//! The current implementation is intentionally simple so the rest of the
-//! journey layer can be wired up against a stable API surface.
+//! Phase 2: waits for two requestAnimationFrame cycles to flush DOM mutations
+//! and CSS transitions before reading focus or AXTree state. Falls back to a
+//! fixed sleep when the JS evaluation fails.
 
 use std::time::Duration;
 
+use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
 use chromiumoxide::Page;
 
-use crate::error::Result;
+use crate::error::{AuditError, Result};
 
-/// Default settle duration after an interaction.
+/// Default settle duration used as fallback when JS evaluation is unavailable.
 pub const DEFAULT_SETTLE_MS: u64 = 150;
 
-/// Wait for the page to settle. Currently a fixed sleep — kept behind a
-/// function so Phase 2 can swap in MutationObserver-based quiescence
-/// without touching every caller.
-pub async fn wait_for_stable(_page: &Page, duration_ms: u64) -> Result<()> {
-    tokio::time::sleep(Duration::from_millis(duration_ms)).await;
+/// Wait for the page to settle after an interaction.
+///
+/// Runs a JS promise that resolves after two animation frames, which flushes
+/// pending DOM mutations and CSS transitions. Falls back to a fixed sleep if
+/// JS evaluation fails (e.g. page is navigating or JS context was destroyed).
+pub async fn wait_for_stable(page: &Page, duration_ms: u64) -> Result<()> {
+    let js = "new Promise(function(r) { requestAnimationFrame(function() { requestAnimationFrame(r); }); })";
+    let params = EvaluateParams::builder()
+        .expression(js.to_string())
+        .await_promise(true)
+        .build()
+        .map_err(|e| AuditError::InteractionFailed {
+            reason: format!("settle build failed: {e}"),
+        })?;
+    if page.execute(params).await.is_err() {
+        tokio::time::sleep(Duration::from_millis(duration_ms)).await;
+    }
     Ok(())
 }
 

--- a/src/patterns/accordion.rs
+++ b/src/patterns/accordion.rs
@@ -8,7 +8,7 @@ use crate::accessibility::AXTree;
 use crate::cli::WcagLevel;
 use crate::wcag::types::{Severity, Violation};
 
-use super::{PatternAnalysis, PatternConfidence};
+use super::{JourneyCandidate, JourneyKind, PatternAnalysis, PatternConfidence, PatternKind};
 
 pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
     let mut triggers = 0usize;
@@ -102,6 +102,37 @@ pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
         ),
         confidence,
     );
+
+    // Emit journey candidates for interactive accordion verification.
+    // Only button-role triggers, skip nav/banner contexts (handled by DisclosureMenu).
+    for node in tree.iter() {
+        if node.get_property_bool("expanded").is_none() {
+            continue;
+        }
+        let role = node.role.as_deref().unwrap_or("");
+        if matches!(
+            role,
+            "dialog" | "alertdialog" | "menu" | "combobox" | "listbox"
+        ) {
+            continue;
+        }
+        if role != "button" {
+            continue;
+        }
+        if in_nav_or_banner(node, tree) {
+            continue;
+        }
+        let has_controls = node.has_property("controls");
+        if let Some(bid) = node.backend_dom_node_id {
+            out.journey_candidates.push(JourneyCandidate {
+                pattern_kind: PatternKind::Accordion,
+                trigger_backend_id: Some(bid),
+                controlled_backend_id: None,
+                confidence: if has_controls { 0.85 } else { 0.7 },
+                required_journey: JourneyKind::AccordionToggle,
+            });
+        }
+    }
 }
 
 fn in_nav_or_banner(node: &crate::accessibility::AXNode, tree: &AXTree) -> bool {

--- a/src/patterns/disclosure_menu.rs
+++ b/src/patterns/disclosure_menu.rs
@@ -9,7 +9,7 @@ use crate::accessibility::AXTree;
 use crate::cli::WcagLevel;
 use crate::wcag::types::{Severity, Violation};
 
-use super::{PatternAnalysis, PatternConfidence};
+use super::{JourneyCandidate, JourneyKind, PatternAnalysis, PatternConfidence, PatternKind};
 
 pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
     let buttons = tree.nodes_with_role("button");
@@ -50,6 +50,33 @@ pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
         )
     };
     out.add_recognized("DisclosureMenu", detail, confidence);
+
+    // Emit journey candidates for interactive disclosure/menu verification.
+    for btn in &buttons {
+        if btn.get_property_bool("expanded").is_none() {
+            continue;
+        }
+        let haspopup = btn.get_property_str("haspopup");
+        let is_menu = matches!(haspopup, Some("menu") | Some("true"));
+        let has_controls = btn.has_property("controls");
+        if let Some(bid) = btn.backend_dom_node_id {
+            out.journey_candidates.push(JourneyCandidate {
+                pattern_kind: if is_menu {
+                    PatternKind::Menu
+                } else {
+                    PatternKind::Disclosure
+                },
+                trigger_backend_id: Some(bid),
+                controlled_backend_id: None,
+                confidence: if has_controls { 0.8 } else { 0.7 },
+                required_journey: if is_menu {
+                    JourneyKind::MenuOpen
+                } else {
+                    JourneyKind::DisclosureToggle
+                },
+            });
+        }
+    }
 
     // Flag toggle-like nodes that look like menus but lack aria-expanded.
     // Heuristic: a `generic` or `link` node whose name contains "menu" /

--- a/src/patterns/modal_dialog.rs
+++ b/src/patterns/modal_dialog.rs
@@ -8,7 +8,7 @@ use crate::accessibility::AXTree;
 use crate::cli::WcagLevel;
 use crate::wcag::types::{Severity, Violation};
 
-use super::{PatternAnalysis, PatternConfidence};
+use super::{JourneyCandidate, JourneyKind, PatternAnalysis, PatternConfidence, PatternKind};
 
 pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
     let dialogs: Vec<_> = tree
@@ -85,6 +85,26 @@ pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
         ),
         confidence,
     );
+
+    // Emit journey candidates for buttons/links that declare aria-haspopup="dialog".
+    for node in tree.iter() {
+        if !matches!(node.role.as_deref(), Some("button") | Some("link")) {
+            continue;
+        }
+        let haspopup = node.get_property_str("haspopup");
+        if !matches!(haspopup, Some("dialog")) {
+            continue;
+        }
+        if let Some(bid) = node.backend_dom_node_id {
+            out.journey_candidates.push(JourneyCandidate {
+                pattern_kind: PatternKind::Modal,
+                trigger_backend_id: Some(bid),
+                controlled_backend_id: None,
+                confidence: 0.85,
+                required_journey: JourneyKind::ModalOpen,
+            });
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/patterns/skip_link.rs
+++ b/src/patterns/skip_link.rs
@@ -6,7 +6,7 @@
 
 use crate::accessibility::AXTree;
 
-use super::{PatternAnalysis, PatternConfidence};
+use super::{JourneyCandidate, JourneyKind, PatternAnalysis, PatternConfidence, PatternKind};
 
 fn collect_links<'a>(
     tree: &'a AXTree,
@@ -83,6 +83,20 @@ pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
         )
     };
     out.add_recognized("SkipLink", message, confidence);
+
+    // Emit journey candidates for interactive skip-link verification.
+    for candidate in &candidates {
+        if let Some(bid) = candidate.backend_dom_node_id {
+            let candidate_confidence = if is_first { 0.9 } else { 0.7 };
+            out.journey_candidates.push(JourneyCandidate {
+                pattern_kind: PatternKind::SkipLink,
+                trigger_backend_id: Some(bid),
+                controlled_backend_id: None,
+                confidence: candidate_confidence,
+                required_journey: JourneyKind::SkipLinkActivate,
+            });
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/patterns/tab_list.rs
+++ b/src/patterns/tab_list.rs
@@ -11,7 +11,7 @@ use crate::accessibility::AXTree;
 use crate::cli::WcagLevel;
 use crate::wcag::types::{Severity, Violation};
 
-use super::{PatternAnalysis, PatternConfidence};
+use super::{JourneyCandidate, JourneyKind, PatternAnalysis, PatternConfidence, PatternKind};
 
 pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
     let tablists = tree.nodes_with_role("tablist");
@@ -78,6 +78,26 @@ pub fn detect(tree: &AXTree, out: &mut PatternAnalysis) {
         ),
         confidence,
     );
+
+    // Emit journey candidates: one per tablist using the first tab as trigger.
+    for tablist in &tablists {
+        let first_tab = tablist
+            .child_ids
+            .iter()
+            .filter_map(|id| tree.get_node(id))
+            .find(|c| c.role.as_deref() == Some("tab"));
+        if let Some(tab) = first_tab {
+            if let Some(bid) = tab.backend_dom_node_id {
+                out.journey_candidates.push(JourneyCandidate {
+                    pattern_kind: PatternKind::Tabs,
+                    trigger_backend_id: Some(bid),
+                    controlled_backend_id: None,
+                    confidence: 0.8,
+                    required_journey: JourneyKind::TabsNavigate,
+                });
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/source_quality/mod.rs
+++ b/src/source_quality/mod.rs
@@ -756,6 +756,7 @@ mod tests {
             consent_banner_cmp: None,
             consent_banner_dismissed: false,
             accessibility_journey: None,
+            interactive_findings: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 2 des Accessibility-Journey-Layers. Erste Phase mit echter **Bewertung** statt nur Aufzeichnung.

- **Stability**: RAF-basiertes Settle (2 Animation-Frames per JS Promise) ersetzt fixen 150ms Sleep
- **Focus-Indicator-Detection**: `Detected`/`NotDetected`/`Ambiguous` via Computed-Style (`outline` + `box-shadow`); `FocusSnapshot` bekommt `aria_hidden_chain`, `inert_chain`, `hidden_by_style`
- **AXTreeDiff**: Property-Level-Diffing für `expanded`/`hidden`/`selected`/`invalid`/`modal`
- **Pattern-Detektoren** emittieren jetzt `JourneyCandidate`s: Skip-Link, Modal (via `aria-haspopup="dialog"`), Disclosure/Menu, Accordion, Tabs
- **Journey-Module** (neu): `skip_link`, `modal_journey`, `disclosure_journey`, `tabs_journey`, `menu_journey`
- **Evaluator** (`evaluate.rs`): pure Funktion für Tab-Walk-Findings (Hidden Focusables: `High`/`High`/`Medium`)
- **Orchestrator** (`mod.rs`): Budget-aware Loop, `RunOutput { journey, findings }`, Phase-3-Stub für `FormErrorSubmit`
- **`AuditReport`**: neues Feld `interactive_findings`, Pipeline leitet korrekt weiter

## Test plan

- [x] `cargo check --all-features` — clean
- [x] `cargo test --lib` — 749 passed, 0 failed
- [ ] Manuell gegen eine Seite mit bekanntem Modal/Skip-Link prüfen: `auditmysite <URL> --interactive=basic --format json`
- [ ] Auf Good-Practice-Baseline keine Critical Findings

Closes #296