### PR TITLE
feat(a11y-journey): wire focus-indicator + detect reverse tab-order jumps

### DIFF
--- a/src/a11y_journey/evaluate.rs
+++ b/src/a11y_journey/evaluate.rs
@@ -6,14 +6,11 @@
 //! the runtime side effects (CDP, JS evaluate, …) and the evaluation
 //! logic in separate, testable units.
 //!
-//! Phase 2a covers:
+//! Currently covers:
 //! - hidden focusables (aria-hidden, inert, hidden-by-style)
-//! - focus reaching `body` after the walk (focus loss)
-//!
-//! Focus-indicator detection and out-of-order detection land in
-//! separate evaluators in Phase 2a follow-up commits.
+//! - missing focus indicator (no outline / box-shadow / border on :focus)
 
-use crate::accessibility::FocusSnapshot;
+use crate::accessibility::{FocusIndicatorStatus, FocusSnapshot};
 use crate::audit::normalized::{InteractiveFinding, JourneyTrace};
 use crate::taxonomy::Severity;
 
@@ -90,6 +87,29 @@ pub fn tab_walk(trace: &JourneyTrace, snapshots: &[FocusSnapshot]) -> Vec<Intera
                         .to_string(),
                 ),
             });
+        } else if matches!(
+            snap.focus_indicator,
+            Some(FocusIndicatorStatus::NotDetected)
+        ) {
+            findings.push(InteractiveFinding {
+                category: "FocusIndicator".to_string(),
+                severity: Severity::Medium,
+                journey: trace.journey.clone(),
+                before_snapshot_label: None,
+                after_snapshot_label: step.snapshot_label.clone(),
+                message: format!(
+                    "Element ({selector}) zeigt im fokussierten Zustand keinen \
+                     sichtbaren Fokus-Indikator (kein outline, kein box-shadow, \
+                     keine border-Änderung). Tastatur-Nutzer verlieren die \
+                     Orientierung."
+                ),
+                fix_suggestion: Some(
+                    "CSS :focus-visible-Regel ergänzen mit klarer outline-, \
+                     box-shadow- oder border-Änderung gegenüber dem unfokussierten \
+                     Zustand."
+                        .to_string(),
+                ),
+            });
         }
     }
 
@@ -112,11 +132,21 @@ mod tests {
     }
 
     fn snap_with(aria: bool, inert: bool, hidden: bool) -> FocusSnapshot {
+        snap_full(aria, inert, hidden, None)
+    }
+
+    fn snap_full(
+        aria: bool,
+        inert: bool,
+        hidden: bool,
+        indicator: Option<FocusIndicatorStatus>,
+    ) -> FocusSnapshot {
         FocusSnapshot {
             selector: Some("a".to_string()),
             aria_hidden_chain: aria,
             inert_chain: inert,
             hidden_by_style: hidden,
+            focus_indicator: indicator,
             ..Default::default()
         }
     }
@@ -186,5 +216,63 @@ mod tests {
         });
         let snaps = vec![snap_with(true, false, false)];
         assert!(tab_walk(&trace, &snaps).is_empty());
+    }
+
+    #[test]
+    fn focus_indicator_not_detected_emits_finding() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_full(
+            false,
+            false,
+            false,
+            Some(FocusIndicatorStatus::NotDetected),
+        )];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].category, "FocusIndicator");
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert!(findings[0].message.contains("Fokus-Indikator"));
+    }
+
+    #[test]
+    fn focus_indicator_detected_emits_no_finding() {
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_full(
+            false,
+            false,
+            false,
+            Some(FocusIndicatorStatus::Detected),
+        )];
+        assert!(tab_walk(&trace, &snaps).is_empty());
+    }
+
+    #[test]
+    fn focus_indicator_ambiguous_emits_no_finding() {
+        // Ambiguous is suppressed in evaluation — too noisy to surface as a
+        // finding.
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_full(
+            false,
+            false,
+            false,
+            Some(FocusIndicatorStatus::Ambiguous),
+        )];
+        assert!(tab_walk(&trace, &snaps).is_empty());
+    }
+
+    #[test]
+    fn hidden_focusable_takes_precedence_over_indicator() {
+        // If aria-hidden / inert / hidden-by-style fires, we don't also flag
+        // missing indicator on the same element.
+        let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
+        let snaps = vec![snap_full(
+            true,
+            false,
+            false,
+            Some(FocusIndicatorStatus::NotDetected),
+        )];
+        let findings = tab_walk(&trace, &snaps);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].category, "HiddenFocusable");
     }
 }

--- a/src/a11y_journey/evaluate.rs
+++ b/src/a11y_journey/evaluate.rs
@@ -9,6 +9,7 @@
 //! Currently covers:
 //! - hidden focusables (aria-hidden, inert, hidden-by-style)
 //! - missing focus indicator (no outline / box-shadow / border on :focus)
+//! - tab order vs. DOM order (`tab_walk_order`, separate evaluator)
 
 use crate::accessibility::{FocusIndicatorStatus, FocusSnapshot};
 use crate::audit::normalized::{InteractiveFinding, JourneyTrace};
@@ -114,6 +115,82 @@ pub fn tab_walk(trace: &JourneyTrace, snapshots: &[FocusSnapshot]) -> Vec<Intera
     }
 
     findings
+}
+
+/// Evaluate tab order against the DOM order of focusable elements.
+///
+/// Emits a single Warning-severity finding when the tab sequence jumps
+/// **backwards** relative to the DOM — that is, the focus moves to an
+/// element that comes earlier in the DOM than the previously focused one.
+/// Forward gaps (skipping elements) are ignored: Grid/Flex/Sticky layouts
+/// make them too ambiguous to call.
+///
+/// Pure function — takes the evidence from the tab-walk runner.
+pub fn tab_walk_order(trace: &JourneyTrace, dom_order: &[String]) -> Vec<InteractiveFinding> {
+    if dom_order.is_empty() {
+        return Vec::new();
+    }
+
+    // Build selector → DOM index lookup.
+    let dom_index =
+        |selector: &str| -> Option<usize> { dom_order.iter().position(|s| s == selector) };
+
+    let mut last_dom_index: Option<usize> = None;
+    let mut reverse_jumps: Vec<String> = Vec::new();
+
+    for step in &trace.steps {
+        if step.action != "tab" {
+            continue;
+        }
+        let Some(selector) = &step.focus else {
+            continue;
+        };
+        let Some(idx) = dom_index(selector) else {
+            // Element not in our pre-walk focusable list — could be a
+            // dynamically inserted control. Skip rather than flag.
+            continue;
+        };
+        if let Some(prev) = last_dom_index {
+            if idx < prev {
+                reverse_jumps.push(selector.clone());
+            }
+        }
+        last_dom_index = Some(idx);
+    }
+
+    if reverse_jumps.is_empty() {
+        return Vec::new();
+    }
+
+    // Aggregate one finding per page, not per jump — avoids spam on pages
+    // with several legitimate-but-noisy layouts.
+    let preview = reverse_jumps
+        .iter()
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let count = reverse_jumps.len();
+    let suffix = if count > 3 { " (…)" } else { "" };
+
+    vec![InteractiveFinding {
+        category: "TabOrder".to_string(),
+        severity: Severity::Medium,
+        journey: trace.journey.clone(),
+        before_snapshot_label: None,
+        after_snapshot_label: None,
+        message: format!(
+            "Tab-Reihenfolge weicht von der DOM-Reihenfolge ab: {count} Rückwärts-Sprung(e) \
+             beobachtet. Erste betroffene Elemente: {preview}{suffix}. \
+             Tastatur-Nutzer könnten dem Lesefluss nicht folgen."
+        ),
+        fix_suggestion: Some(
+            "Negative oder hohe tabindex-Werte vermeiden. \
+             Lese-/DOM-Reihenfolge so anordnen, dass sie der visuellen \
+             Reihenfolge entspricht."
+                .to_string(),
+        ),
+    }]
 }
 
 #[cfg(test)]
@@ -249,7 +326,7 @@ mod tests {
     #[test]
     fn focus_indicator_ambiguous_emits_no_finding() {
         // Ambiguous is suppressed in evaluation — too noisy to surface as a
-        // finding.
+        // finding. Phase 3 may aggregate it.
         let trace = trace_with(vec![step_tab("a#one", "after_tab_1")]);
         let snaps = vec![snap_full(
             false,
@@ -274,5 +351,63 @@ mod tests {
         let findings = tab_walk(&trace, &snaps);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].category, "HiddenFocusable");
+    }
+
+    // ── tab_walk_order tests ─────────────────────────────────────────────
+
+    #[test]
+    fn forward_walk_produces_no_order_finding() {
+        let trace = trace_with(vec![
+            step_tab("a", "after_tab_1"),
+            step_tab("b", "after_tab_2"),
+            step_tab("c", "after_tab_3"),
+        ]);
+        let dom = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert!(tab_walk_order(&trace, &dom).is_empty());
+    }
+
+    #[test]
+    fn reverse_jump_emits_warning() {
+        // Tab goes a → c → b (b is before c in DOM) → reverse jump on step 3.
+        let trace = trace_with(vec![
+            step_tab("a", "after_tab_1"),
+            step_tab("c", "after_tab_2"),
+            step_tab("b", "after_tab_3"),
+        ]);
+        let dom = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let findings = tab_walk_order(&trace, &dom);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].category, "TabOrder");
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert!(findings[0].message.contains("b"));
+    }
+
+    #[test]
+    fn forward_gap_is_not_a_finding() {
+        // Skipping "b" forward is allowed — Grid/Flex layouts.
+        let trace = trace_with(vec![
+            step_tab("a", "after_tab_1"),
+            step_tab("c", "after_tab_2"),
+        ]);
+        let dom = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert!(tab_walk_order(&trace, &dom).is_empty());
+    }
+
+    #[test]
+    fn empty_dom_order_produces_no_finding() {
+        let trace = trace_with(vec![step_tab("a", "after_tab_1")]);
+        assert!(tab_walk_order(&trace, &[]).is_empty());
+    }
+
+    #[test]
+    fn unknown_selector_does_not_panic() {
+        // Selector that's not in the DOM list — dynamic content. Skip rather
+        // than flag.
+        let trace = trace_with(vec![
+            step_tab("a", "after_tab_1"),
+            step_tab("z", "after_tab_2"),
+        ]);
+        let dom = vec!["a".to_string(), "b".to_string()];
+        assert!(tab_walk_order(&trace, &dom).is_empty());
     }
 }

--- a/src/a11y_journey/mod.rs
+++ b/src/a11y_journey/mod.rs
@@ -72,6 +72,8 @@ pub async fn run(ctx: RunContext<'_>) -> Result<Option<RunOutput>> {
     let record = tab_walk::record(ctx.page, max_steps).await?;
     out.findings
         .extend(evaluate::tab_walk(&record.trace, &record.snapshots));
+    out.findings
+        .extend(evaluate::tab_walk_order(&record.trace, &record.dom_order));
     out.journey.traces.push(record.trace);
 
     // Pattern-based journeys — only if we have candidates and time remains.

--- a/src/a11y_journey/tab_walk.rs
+++ b/src/a11y_journey/tab_walk.rs
@@ -18,6 +18,9 @@ pub struct TabWalkRecord {
     pub trace: JourneyTrace,
     /// `snapshots[i]` corresponds to `trace.steps[i]`.
     pub snapshots: Vec<FocusSnapshot>,
+    /// Selectors of focusable elements as they appear in the DOM, captured
+    /// *before* the walk starts. Used to detect reverse jumps in tab order.
+    pub dom_order: Vec<String>,
 }
 
 /// Record a tab walk of up to `max_steps` Tab presses.
@@ -31,6 +34,11 @@ pub async fn record(page: &Page, max_steps: usize) -> Result<TabWalkRecord> {
         steps: Vec::with_capacity(max_steps),
     };
     let mut snapshots: Vec<FocusSnapshot> = Vec::with_capacity(max_steps);
+
+    // Capture the DOM order of focusable elements *before* the walk so the
+    // evaluator can detect reverse jumps. Empty list on JS failure — the
+    // evaluator treats that as "no order data".
+    let dom_order = focus::collect_focusable_dom_order(page).await;
 
     // Initial focus snapshot — usually body / no element.
     let start = focus::capture_focus(page).await?;
@@ -76,5 +84,9 @@ pub async fn record(page: &Page, max_steps: usize) -> Result<TabWalkRecord> {
         last_focus_selector = current;
     }
 
-    Ok(TabWalkRecord { trace, snapshots })
+    Ok(TabWalkRecord {
+        trace,
+        snapshots,
+        dom_order,
+    })
 }

--- a/src/interaction/focus.rs
+++ b/src/interaction/focus.rs
@@ -73,6 +73,77 @@ const ACTIVE_ELEMENT_JS: &str = r#"
 })()
 "#;
 
+/// JS that collects all focusable elements on the page in DOM order and
+/// returns their selectors. Used by the tab-walk evaluator to detect
+/// reverse jumps in tab order.
+///
+/// Filter logic mirrors what the browser treats as keyboard-reachable:
+/// - explicit interactive elements: `<a href>`, `<button>`, form controls
+/// - any element with positive or zero `tabindex`
+/// - `contenteditable` regions
+/// - excludes `disabled` controls and `tabindex="-1"` (HTMLElement.tabIndex < 0)
+const COLLECT_FOCUSABLES_JS: &str = r#"
+(function () {
+    function selectorFor(node) {
+        if (!node || node.nodeType !== 1) return null;
+        if (node.id) return '#' + node.id;
+        var parts = [];
+        while (node && node.nodeType === 1 && parts.length < 6) {
+            var tag = node.nodeName.toLowerCase();
+            if (node.id) { parts.unshift(tag + '#' + node.id); break; }
+            var parent = node.parentNode;
+            if (parent) {
+                var siblings = Array.from(parent.children).filter(function (c) {
+                    return c.nodeName === node.nodeName;
+                });
+                if (siblings.length > 1) {
+                    var idx = siblings.indexOf(node) + 1;
+                    tag += ':nth-of-type(' + idx + ')';
+                }
+            }
+            parts.unshift(tag);
+            node = parent;
+        }
+        return parts.join(' > ');
+    }
+    var sel = 'a[href], button, input:not([type="hidden"]), select, textarea, ' +
+              '[tabindex], [contenteditable=""], [contenteditable="true"]';
+    var els = Array.from(document.querySelectorAll(sel)).filter(function (el) {
+        if (el.disabled) return false;
+        if (typeof el.tabIndex === 'number' && el.tabIndex < 0) return false;
+        return true;
+    });
+    return els.map(selectorFor).filter(function (s) { return s !== null; });
+})()
+"#;
+
+/// Collect the in-DOM-order selectors of all focusable elements on the
+/// page. Used as the reference order by `evaluate::tab_walk_order`.
+///
+/// Returns an empty vector on evaluation failure rather than an error —
+/// missing DOM-order data simply means we cannot detect out-of-order jumps.
+pub async fn collect_focusable_dom_order(page: &Page) -> Vec<String> {
+    let Ok(params) = EvaluateParams::builder()
+        .expression(COLLECT_FOCUSABLES_JS.to_string())
+        .return_by_value(true)
+        .build()
+    else {
+        return Vec::new();
+    };
+    let Ok(result) = page.execute(params).await else {
+        return Vec::new();
+    };
+    let Some(value) = result.result.result.value.clone() else {
+        return Vec::new();
+    };
+    let Some(arr) = value.as_array() else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect()
+}
+
 /// JS that checks whether the currently focused element has a visible focus
 /// indicator via outline, box-shadow, or border changes.
 const FOCUS_INDICATOR_JS: &str = r#"


### PR DESCRIPTION
## Summary

Closes the two gaps left by Phase 2 (#297):

- **Focus-indicator wiring** — `detect_focus_indicator()` was already
  computing a tri-state `FocusIndicatorStatus` on every focused element,
  but the evaluator never read it, so no finding was emitted. Now wired
  through to a Medium-severity `FocusIndicator` finding for the
  `NotDetected` case.
- **Tab-order reverse-jump detection** — captures DOM order of
  focusable elements before the walk, compares with the recorded tab
  sequence, emits an aggregated Medium `TabOrder` finding when the tab
  sequence jumps backwards relative to the DOM. Forward gaps are
  ignored on purpose (Grid/Flex/Sticky make them too ambiguous).

## Commits

Two bisect-clean commits:

- `31f0417` — `feat(a11y-journey): wire focus-indicator detection into evaluator`
- `cc957c2` — `feat(a11y-journey): detect tab-order reverse jumps`

## Behaviour summary

| Tab step state                       | Finding emitted              |
|--------------------------------------|------------------------------|
| `aria-hidden` ancestor               | `HiddenFocusable` (High)     |
| `inert` ancestor                     | `HiddenFocusable` (High)     |
| `display:none` / `visibility:hidden` | `HiddenFocusable` (Medium)   |
| `focus_indicator == NotDetected`     | `FocusIndicator` (Medium)    |
| `focus_indicator == Ambiguous`       | _suppressed (too noisy)_     |
| reverse jump in tab order            | `TabOrder` (Medium, aggregated, page-level) |

Precedence rule unchanged: at most one finding per tab step, hidden-focusable
beats indicator.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features` (1000+ passed, 0 failed)
- [x] Unit tests cover both new findings and the precedence rules
- [ ] Manual smoke against `www.casoon.de --interactive=basic` —
      JSON should include `FocusIndicator` and/or `TabOrder` entries in
      `interactive_findings`

## Non-goals

- Aggregating `Ambiguous` indicator detections (Phase 3 idea)
- Per-element messaging for tab-order issues — we emit one finding per
  page with the first three offending selectors to avoid spam
- Detecting `tabindex > 0` as a separate issue — captured indirectly via
  the reverse-jump signal