### PR TITLE
fix(report): resolve 13 report-quality issues (#355–#367)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,9 +3973,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renderreport"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d87c6e817394df139ea3472e6e3f1a8aad1b99f16fc66ddffc5cc3e0b6da0d4"
+checksum = "8184ce90610cb95b713be86c00b2440adbed5c095d581e0ad27b0cfa51a44186"
 dependencies = [
  "anyhow",
  "barcoders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ fluent-syntax = "0.11"
 unic-langid = "0.9"
 
 # PDF report generation via Typst.
-renderreport = { version = "0.2.19", optional = true }
+renderreport = { version = "0.2.20", optional = true }
 
 # Local embedding model for semantic link-text evaluation (semantic-eval feature).
 fastembed = { version = "5", optional = true }

--- a/locales/de/report.ftl
+++ b/locales/de/report.ftl
@@ -94,25 +94,25 @@ narrative-next-steps-intro = Konkrete Handlungsempfehlung für die nächsten 1�
 narrative-next-steps-callout-title = Nächster Schritt
 narrative-next-steps-callout-body = Für eine vollständige Barrierefreiheits-Prüfung empfehlen wir ergänzend einen manuellen Audit mit assistiven Technologien (Screenreader, Tastaturnavigation).
 narrative-findings-intro-strong = Die Seite ist technisch stark aufgestellt. Die folgenden Punkte sind letzte Optimierungshebel ohne strukturellen Druck.
-narrative-findings-intro-solid = Solide Basis — die folgenden Punkte sind gezielte Verbesserungshebel.
+narrative-findings-intro-solid = Tragfähige Basis — die folgenden Punkte sind gezielte Verbesserungshebel.
 narrative-findings-intro-default = Die folgenden Probleme haben den größten Einfluss auf Nutzbarkeit und Risiko. Technische Details folgen im nächsten Abschnitt.
 
 # Verdict (single audit)
 verdict-tier-excellent = { $url } erreicht { $score }/100 im Accessibility-Audit. Die verbleibenden Findings sind letzte Optimierungshebel — kein strukturelles Problem, sondern Feinschliff.
-verdict-tier-solid = { $url } erreicht { $score }/100 im Accessibility-Audit. Die Basis ist solide — klarer Verbesserungshebel mit überschaubarem Aufwand.
+verdict-tier-solid = { $url } erreicht { $score }/100 im Accessibility-Audit. Die Grundlage ist stabil — klarer Verbesserungshebel mit überschaubarem Aufwand.
 verdict-tier-deficient = { $url } erreicht { $score }/100 im Accessibility-Audit. Es bestehen deutliche Barrieren — nicht nur Detailprobleme, sondern struktureller Nachholbedarf.
 verdict-tier-critical = { $url } erreicht nur { $score }/100 im Accessibility-Audit. Akuter Handlungsbedarf: Wesentliche Inhalte und Funktionen sind für einen Teil der Nutzer nicht zugänglich.
 score-note-high-with-critical = Der Score berücksichtigt Gewichtung und Häufigkeit. Einzelne kritische Themen können trotz hoher Gesamtbewertung bestehen.
 
 # Verdict (batch audit)
 verdict-batch-excellent = Über { $total_urls } geprüfte URLs hinweg erreicht die Website einen Gesamtscore von { $score }/100 — ein sehr gutes Ergebnis.
-verdict-batch-solid = Im Durchschnitt erreichen die { $total_urls } geprüften URLs einen Gesamtscore von { $score }/100. Die Basis ist solide, es bestehen aber wiederkehrende Probleme in einzelnen Modulen.
+verdict-batch-solid = Im Durchschnitt erreichen die { $total_urls } geprüften URLs einen Gesamtscore von { $score }/100. Die Grundlage ist stabil, es bestehen aber wiederkehrende Probleme in einzelnen Modulen.
 verdict-batch-deficient = Die { $total_urls } geprüften URLs erreichen im Schnitt nur { $score }/100 Punkte. Es bestehen erhebliche systematische Probleme.
 verdict-batch-critical = Die { $total_urls } geprüften URLs erreichen im Schnitt nur { $score }/100 Punkte. Dringender Handlungsbedarf in mehreren Modulen.
 
 # Site state (audit summary)
 site-state-polished = Stark
-site-state-needs-work = Solide Basis
+site-state-needs-work = Tragfähige Basis
 site-state-weak = Instabil
 site-state-critical = Kritisch
 
@@ -355,12 +355,13 @@ finding-reference = Referenz
 
 # SEO / Tracking section
 seo-tracking-services = Tracking und externe Dienste
-seo-kv-title = Technisches SEO
+seo-kv-title = Technische SEO-Signale
 seo-serp-readiness = SERP-Bereitschaft
 seo-serp-signals = SERP-Signale
 seo-page-health-issues = Gefundene Probleme
 seo-page-health-url-analysis = URL-Analyse
 seo-page-html-validation = HTML-Validierung
+seo-technical-issues-title = Technische SEO-Probleme
 
 # Security section
 security-score-card = Security Score
@@ -372,6 +373,10 @@ mobile-touch-targets = Touch Targets
 mobile-viewport-config = Viewport-Konfiguration
 mobile-font-analysis = Schriftanalyse
 mobile-content-sizing = Inhaltsanpassung
+mobile-cat-viewport = Viewport
+mobile-cat-touch_targets = Touch-Targets
+mobile-cat-fonts = Schriftgrößen
+mobile-cat-content = Inhaltsanpassung
 
 # AI Visibility section
 ai-score-card = AI-Sichtbarkeit (Indikator)
@@ -432,7 +437,7 @@ effect-conversion-heading = Strukturklarheit → schnellere Orientierung
 effect-conversion-language = Korrekte Sprachausgabe → keine Abbrüche durch Vorlesefehler
 effect-conversion-default-quick = Schnell wirksam — messbar innerhalb von Tagen
 effect-conversion-default-medium = Mittelfristig messbare UX-Verbesserung
-effect-conversion-default-structural = Solide technische Basis für weiteres Wachstum
+effect-conversion-default-structural = Stabile technische Basis für weiteres Wachstum
 
 # Narrative Arc Formatters
 narrative-diagnose-multiple = { $count }× festgestellt: { $desc }

--- a/locales/en/report.ftl
+++ b/locales/en/report.ftl
@@ -94,25 +94,25 @@ narrative-next-steps-intro = Concrete recommendation for the next 1–4 weeks.
 narrative-next-steps-callout-title = Next step
 narrative-next-steps-callout-body = For a complete accessibility verification we additionally recommend a manual audit with assistive technologies (screen reader, keyboard navigation).
 narrative-findings-intro-strong = The site is technically strong. The following items are last optimization levers without structural pressure.
-narrative-findings-intro-solid = Solid foundation — the following items are targeted improvement levers.
+narrative-findings-intro-solid = Stable foundation — the following items are targeted improvement levers.
 narrative-findings-intro-default = The following issues have the largest impact on usability and risk. Technical details follow in the next section.
 
 # Verdict (single audit)
 verdict-tier-excellent = { $url } reaches { $score }/100 in the accessibility audit. The remaining findings are last optimization levers — not a structural problem but polish.
-verdict-tier-solid = { $url } reaches { $score }/100 in the accessibility audit. The foundation is solid — clear improvement levers at manageable effort.
+verdict-tier-solid = { $url } reaches { $score }/100 in the accessibility audit. The foundation is stable — clear improvement levers at manageable effort.
 verdict-tier-deficient = { $url } reaches { $score }/100 in the accessibility audit. There are significant barriers — not isolated details but structural backlog.
 verdict-tier-critical = { $url } only reaches { $score }/100 in the accessibility audit. Urgent action needed: essential content and functions are not accessible for a part of users.
 score-note-high-with-critical = The score weighs frequency and severity. Individual critical topics can persist despite a high overall score.
 
 # Verdict (batch audit)
 verdict-batch-excellent = Across { $total_urls } audited URLs the site reaches an overall score of { $score }/100 — a very good result.
-verdict-batch-solid = On average the { $total_urls } audited URLs reach an overall score of { $score }/100. The foundation is solid, but recurring issues exist in individual modules.
+verdict-batch-solid = On average the { $total_urls } audited URLs reach an overall score of { $score }/100. The foundation is stable, but recurring issues exist in individual modules.
 verdict-batch-deficient = The { $total_urls } audited URLs reach on average only { $score }/100 points. There are significant systematic problems.
 verdict-batch-critical = The { $total_urls } audited URLs reach on average only { $score }/100 points. Urgent action required across multiple modules.
 
 # Site state (audit summary)
 site-state-polished = Strong
-site-state-needs-work = Solid foundation
+site-state-needs-work = Stable foundation
 site-state-weak = Unstable
 site-state-critical = Critical
 
@@ -134,7 +134,7 @@ grade-deficient = Needs work
 grade-critical = Critical
 
 # Business / forward-looking consequence
-business-consequence-clean = No known barriers — solid foundation for all user groups.
+business-consequence-clean = No known barriers — a stable foundation for all user groups.
 business-consequence-severe = Large parts of the site are unusable or barely usable for certain user groups.
 business-consequence-seo-headings = The site is harder to find and structurally inaccessible to part of users.
 business-consequence-screenreader = Individual key functions are blocked or unreliable for screen-reader users.
@@ -355,12 +355,13 @@ finding-reference = Reference
 
 # SEO / Tracking section
 seo-tracking-services = Tracking and external services
-seo-kv-title = Technical SEO
+seo-kv-title = Technical SEO signals
 seo-serp-readiness = SERP readiness
 seo-serp-signals = SERP signals
 seo-page-health-issues = Detected issues
 seo-page-health-url-analysis = URL analysis
 seo-page-html-validation = HTML validation
+seo-technical-issues-title = Technical SEO issues
 
 # Security section
 security-score-card = Security score
@@ -372,6 +373,10 @@ mobile-touch-targets = Touch targets
 mobile-viewport-config = Viewport configuration
 mobile-font-analysis = Font analysis
 mobile-content-sizing = Content sizing
+mobile-cat-viewport = Viewport
+mobile-cat-touch_targets = Touch targets
+mobile-cat-fonts = Font sizes
+mobile-cat-content = Content sizing
 
 # AI Visibility section
 ai-score-card = AI visibility (indicator)

--- a/src/ai_visibility/citation.rs
+++ b/src/ai_visibility/citation.rs
@@ -195,7 +195,7 @@ pub(crate) fn analyze_citation(input: &CitationInput) -> CitationAnalysis {
                 .map_or("n/a".to_string(), |s| format!("{}", s)),
             input.a11y_score,
             if tech_trust {
-                "solide technische Basis"
+                "stabile technische Basis"
             } else {
                 "technische Schwächen mindern Vertrauen"
             }

--- a/src/audit/catalog.rs
+++ b/src/audit/catalog.rs
@@ -192,8 +192,8 @@ impl AuditCatalog {
     /// the error internally and return `Ok(ModuleData::None)` — that
     /// mirrors today's `extract_snapshot` behavior where a failing
     /// sub-analysis logs a warning and yields `None`.
-    pub async fn collect_all<'a>(
-        &'a self,
+    pub async fn collect_all(
+        &self,
         ctx: &ModuleContext<'_>,
     ) -> Result<Vec<(&'static str, ModuleData)>> {
         let mut ordered = self.topo_sorted()?;

--- a/src/audit/interpretation.rs
+++ b/src/audit/interpretation.rs
@@ -103,7 +103,7 @@ impl Interpretation {
         let benchmark_context = build_benchmark_context_localized(ctx.overall_score as f32);
         let business_consequence_key = pick_business_consequence_key(ctx);
         let consequence_key = pick_consequence_key(ctx);
-        let verdict_key = pick_verdict_key(ctx.overall_score as f32);
+        let verdict_key = pick_verdict_key(ctx.overall_score as f32, ctx.risk.legal_flags);
         let score_note_key = pick_score_note_key(ctx);
         let batch_verdict_key = String::new();
 
@@ -683,7 +683,17 @@ fn pick_consequence_key(normalized: &AuditContext) -> String {
     .to_string()
 }
 
-fn pick_verdict_key(score: f32) -> String {
+fn pick_verdict_key(score: f32, legal_flags: usize) -> String {
+    // A page with legal-relevant Level-A findings must never receive the
+    // reassuring "solid" verdict, regardless of an otherwise passable score (#356).
+    if legal_flags > 0 {
+        return if score < 50.0 {
+            "verdict-tier-critical"
+        } else {
+            "verdict-tier-deficient"
+        }
+        .to_string();
+    }
     if score >= 90.0 {
         "verdict-tier-excellent"
     } else if score >= 70.0 {

--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -274,19 +274,16 @@ pub struct ModuleScoreEntry {
 
 /// Risk level — independent from score.
 /// Score = quality level, Risk = operational/legal relevance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum RiskLevel {
+    #[default]
     Low,
     Medium,
     High,
     Critical,
-}
-
-impl Default for RiskLevel {
-    fn default() -> Self {
-        Self::Low
-    }
 }
 
 impl std::fmt::Display for RiskLevel {

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -1051,7 +1051,7 @@ mod tests {
                 WcagLevel::A,
                 crate::wcag::Severity::Critical,
                 "missing",
-                &format!("n{i}"),
+                format!("n{i}"),
             ));
         }
         let risky = normalize(&AuditReport::new(

--- a/src/audit/summary.rs
+++ b/src/audit/summary.rs
@@ -48,7 +48,7 @@ impl SiteState {
     pub fn label(&self) -> &str {
         match self {
             Self::Polished => "Stark",
-            Self::NeedsWork => "Solide Basis",
+            Self::NeedsWork => "Tragfähige Basis",
             Self::Weak => "Instabil",
             Self::Critical => "Kritisch",
         }
@@ -412,16 +412,16 @@ fn build_verdict_intro(
                     format!("No pressing barriers detected by automation.{cross_note} Maintain the level and re-check regularly.")
                 } else {
                     let topic_word = if urgent == 1 { "topic" } else { "topics" };
-                    format!("Solid foundation. {urgent} prioritized {topic_word} — fix deliberately before they pile up.{cross_note}")
+                    format!("Stable foundation. {urgent} prioritized {topic_word} — fix deliberately before they pile up.{cross_note}")
                 }
             }
             (SiteState::NeedsWork, IssuePattern::Clustered) => format!(
-                "Solid foundation, but {urgent} prioritized topics span several independent areas. \
+                "Stable foundation, but {urgent} prioritized topics span several independent areas. \
                  Prioritize systematically — not all at once.{cross_note}"
             ),
             (SiteState::NeedsWork, _) => {
                 if urgent == 0 {
-                    format!("Solid foundation without acute risks. {total} improvements possible — easy to prioritize.{cross_note}")
+                    format!("Stable foundation without acute risks. {total} improvements possible — easy to prioritize.{cross_note}")
                 } else {
                     let topic_word = if urgent == 1 { "topic" } else { "topics" };
                     let needs_word = if urgent == 1 { "needs" } else { "need" };
@@ -445,7 +445,7 @@ fn build_verdict_intro(
                 format!("Automatisiert unauffällig — keine dringenden Barrieren erkannt.{cross_note} Niveau halten und regelmäßig nachprüfen.")
             } else {
                 format!(
-                    "Solide Basis. {} priorisierte{} Thema{} — gezielt beheben, bevor sie sich häufen.{cross_note}",
+                    "Tragfähige Basis. {} priorisierte{} Thema{} — gezielt beheben, bevor sie sich häufen.{cross_note}",
                     urgent,
                     if urgent == 1 { "s" } else { "" },
                     if urgent == 1 { "" } else { "n" }
@@ -453,12 +453,12 @@ fn build_verdict_intro(
             }
         }
         (SiteState::NeedsWork, IssuePattern::Clustered) => format!(
-            "Solide Basis, aber {urgent} priorisierte Themen verteilen sich auf mehrere unabhängige Bereiche. \
+            "Tragfähige Basis, aber {urgent} priorisierte Themen verteilen sich auf mehrere unabhängige Bereiche. \
              Strukturiert priorisieren — nicht alles auf einmal.{cross_note}"
         ),
         (SiteState::NeedsWork, _) => {
             if urgent == 0 {
-                format!("Solide Basis ohne akute Risiken. {total} Verbesserungen möglich — gut priorisierbar.{cross_note}")
+                format!("Tragfähige Basis ohne akute Risiken. {total} Verbesserungen möglich — gut priorisierbar.{cross_note}")
             } else {
                 format!(
                     "Gute Basis, aber {} priorisierte{} Thema{} braucht{} sofortige Aufmerksamkeit.{cross_note}",

--- a/src/output/builder/single/executive.rs
+++ b/src/output/builder/single/executive.rs
@@ -69,8 +69,20 @@ pub(super) fn build_executive_narrative(
 ) -> ExecutiveNarrativeBlock {
     let en = i18n.locale() == "en";
     let assessment = build_single_assessment_text(i18n.locale(), score, severity);
-    let key_points =
-        build_single_key_points_text(i18n.locale(), severity, top_findings, normalized);
+    // Single source of truth for "share of critical/high findings from the
+    // dominant issue". Both the key-points line and the leverage text below must
+    // use this value — never an independently recomputed percentage (#360).
+    let dominant_share = audit_summary
+        .dominant_issue
+        .as_ref()
+        .map(|d| d.share_pct.round() as usize);
+    let key_points = build_single_key_points_text(
+        i18n.locale(),
+        severity,
+        top_findings,
+        normalized,
+        dominant_share,
+    );
     let (user_label, business_label, risk_label) = if en {
         ("User", "Business", "Risk")
     } else {
@@ -160,9 +172,11 @@ pub(super) fn build_executive_narrative(
     ) =
         top_findings.first()
     {
-        let share = (top.occurrence_count * 100)
-            .checked_div(total_ch)
-            .unwrap_or(0);
+        let share = dominant_share.unwrap_or_else(|| {
+            (top.occurrence_count * 100)
+                .checked_div(total_ch)
+                .unwrap_or(0)
+        });
         (
                 audit_summary.dominant_issue_note.clone().unwrap_or_else(|| {
                     if en {
@@ -247,39 +261,86 @@ pub(super) fn build_executive_narrative(
     }
 }
 
+/// Assessment label for the executive cover. The score band is the primary
+/// signal (bands per CLAUDE.md: ≥90/≥75/≥60/≥40/<40); severity only refines the
+/// wording *within* a band. A low score must never yield a reassuring label —
+/// e.g. "Gute Basis" may only appear from score ≥ 60 upward.
 fn build_single_assessment_text(locale: &str, score: u32, severity: &SeverityBlock) -> String {
     let en = locale == "en";
     let has_critical_a11y = severity.critical > 0;
     let has_high = severity.high > 0;
 
-    if has_critical_a11y && score < 50 {
+    if score < 40 {
+        // Critical band — never a "good foundation" wording, regardless of severity mix.
         if en {
             "Critical barriers — not WCAG conformant".to_string()
         } else {
             "Kritische Barrieren — nicht WCAG-konform".to_string()
         }
-    } else if has_critical_a11y {
-        if en {
-            "Technically solid, but legally risky".to_string()
+    } else if score < 60 {
+        // Inadequate band: relevant barriers, no reassurance.
+        if has_critical_a11y {
+            if en {
+                "Serious barriers — not WCAG conformant".to_string()
+            } else {
+                "Gravierende Barrieren — nicht WCAG-konform".to_string()
+            }
+        } else if en {
+            "Substantial accessibility gaps".to_string()
         } else {
-            "Technisch stabil, aber rechtlich riskant".to_string()
+            "Erhebliche Barrierefreiheitslücken".to_string()
         }
-    } else if has_high {
-        if en {
-            "Good foundation, but not accessible".to_string()
+    } else if score < 75 {
+        // Needs-improvement band.
+        if has_critical_a11y {
+            if en {
+                "Usable, but legally risky".to_string()
+            } else {
+                "Nutzbar, aber rechtlich riskant".to_string()
+            }
+        } else if has_high {
+            if en {
+                "Usable foundation, but not yet accessible".to_string()
+            } else {
+                "Nutzbare Basis, aber noch nicht barrierefrei".to_string()
+            }
+        } else if en {
+            "Needs improvement toward accessibility".to_string()
         } else {
-            "Gute Basis, aber nicht barrierefrei".to_string()
+            "Verbesserungswürdig auf dem Weg zur Barrierefreiheit".to_string()
         }
-    } else if score >= 85 {
-        if en {
+    } else if score < 90 {
+        // Good band.
+        if has_critical_a11y {
+            if en {
+                "Technically stable, but legally risky".to_string()
+            } else {
+                "Technisch stabil, aber rechtlich riskant".to_string()
+            }
+        } else if has_high {
+            if en {
+                "Good foundation, but not accessible".to_string()
+            } else {
+                "Gute Basis, aber nicht barrierefrei".to_string()
+            }
+        } else if en {
+            "Largely accessible — fine-tuning".to_string()
+        } else {
+            "Weitgehend barrierefrei — Feinschliff".to_string()
+        }
+    } else {
+        // Excellent band.
+        if has_high {
+            if en {
+                "Largely accessible — close residual gaps".to_string()
+            } else {
+                "Weitgehend barrierefrei — Restlücken schließen".to_string()
+            }
+        } else if en {
             "Largely accessible — polish".to_string()
         } else {
             "Weitgehend barrierefrei — Feinschliff".to_string()
         }
-    } else if en {
-        "Solid foundation with room to optimize".to_string()
-    } else {
-        "Stabile Grundlage mit Optimierungspotenzial".to_string()
     }
 }
 
@@ -288,6 +349,7 @@ fn build_single_key_points_text(
     severity: &SeverityBlock,
     top_findings: &[FindingGroup],
     normalized: &NormalizedReport,
+    dominant_share: Option<usize>,
 ) -> Vec<String> {
     let en = locale == "en";
     let mut points = Vec::with_capacity(3);
@@ -307,9 +369,13 @@ fn build_single_key_points_text(
 
     if let Some(top) = top_findings.first() {
         let total_ch = (severity.critical + severity.high) as usize;
-        let share = (top.occurrence_count * 100)
-            .checked_div(total_ch)
-            .unwrap_or(0);
+        // Prefer the canonical dominant-issue share so this line and the
+        // leverage text never disagree on the same percentage (#360).
+        let share = dominant_share.unwrap_or_else(|| {
+            (top.occurrence_count * 100)
+                .checked_div(total_ch)
+                .unwrap_or(0)
+        });
         if share >= 30 {
             if en {
                 points.push(format!(

--- a/src/output/builder/single/findings.rs
+++ b/src/output/builder/single/findings.rs
@@ -15,7 +15,11 @@ pub(super) fn finding_group_from_normalized(
     f: &crate::audit::normalized::NormalizedFinding,
 ) -> FindingGroup {
     let locale = i18n.locale();
-    let explanation = get_explanation(&f.wcag_criterion);
+    // Try the taxonomy rule_id first (e.g. "a11y.aria_hidden_focus.invalid"),
+    // then fall back to the WCAG criterion. Some rules carry their localized
+    // explanation under the taxonomy key, not the WCAG number — looking up by
+    // wcag_criterion alone left those findings with the raw English fix (#357).
+    let explanation = get_explanation(&f.rule_id).or_else(|| get_explanation(&f.wcag_criterion));
 
     let (
         title,

--- a/src/output/builder/single/mod.rs
+++ b/src/output/builder/single/mod.rs
@@ -616,7 +616,7 @@ mod tests {
 
         // Site state (maturity_label) must be one of the English variants.
         assert!(
-            ["Strong", "Solid foundation", "Unstable", "Critical"]
+            ["Strong", "Stable foundation", "Unstable", "Critical"]
                 .contains(&vm.summary.maturity_label.as_str()),
             "Maturity label should be English, got {}",
             vm.summary.maturity_label

--- a/src/output/builder/single/module_details.rs
+++ b/src/output/builder/single/module_details.rs
@@ -33,6 +33,161 @@ fn module_interpretation(normalized: &NormalizedReport, module: &str, locale: &s
         .unwrap_or_default()
 }
 
+/// Joins phrases into a natural list ("a, b and c" / "a, b und c").
+fn join_phrases(items: &[String], en: bool) -> String {
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].clone(),
+        _ => {
+            let (last, head) = items.split_last().unwrap();
+            format!(
+                "{} {} {}",
+                head.join(", "),
+                if en { "and" } else { "und" },
+                last
+            )
+        }
+    }
+}
+
+/// Appends threshold-based qualifiers to the performance interpretation so that
+/// concrete weak metrics (DOM complexity, throttled LCP, render-blocking
+/// resources, unminified weight, non-composited animations) are named instead
+/// of left to the score band alone, while genuinely strong metrics (CLS, TBT)
+/// are acknowledged as contrast (#367).
+fn append_performance_qualifiers(
+    base: String,
+    p: &crate::PerformanceResults,
+    normalized: &AuditContext,
+    en: bool,
+) -> String {
+    let mut critical: Vec<String> = Vec::new();
+
+    if let Some(nodes) = p.vitals.dom_nodes.filter(|n| *n > 3000) {
+        critical.push(if en {
+            format!("high DOM complexity ({nodes} nodes)")
+        } else {
+            format!("die hohe DOM-Komplexität ({nodes} Knoten)")
+        });
+    }
+
+    // Worst LCP measured under network throttling (e.g. Slow 3G).
+    let throttled_lcp = normalized
+        .raw_throttled_performance
+        .iter()
+        .filter_map(|t| t.lcp_ms)
+        .fold(0.0_f64, f64::max);
+    if throttled_lcp > 4000.0 {
+        critical.push(if en {
+            format!("a late largest contentful paint under throttling ({throttled_lcp:.0} ms)")
+        } else {
+            format!(
+                "der spät erscheinende Hauptinhalt unter Drosselung ({throttled_lcp:.0} ms LCP)"
+            )
+        });
+    }
+
+    let rb_count = p
+        .render_blocking
+        .as_ref()
+        .map(|rb| rb.blocking_scripts.len() + rb.blocking_css.len())
+        .unwrap_or(0);
+    if rb_count > 0 {
+        critical.push(if en {
+            format!("{rb_count} render-blocking resources")
+        } else {
+            format!("{rb_count} render-blockierende Ressourcen")
+        });
+    }
+
+    let unminified_kb = p
+        .minification
+        .as_ref()
+        .map(|m| m.total_savings_bytes as f64 / 1024.0)
+        .unwrap_or(0.0);
+    if unminified_kb > 100.0 {
+        critical.push(if en {
+            format!("unminified assets (~{unminified_kb:.0} KB savings)")
+        } else {
+            format!("unminifizierte Assets (~{unminified_kb:.0} KB Einsparpotenzial)")
+        });
+    }
+
+    let anim_count = p.animations.as_ref().map(|a| a.total_count).unwrap_or(0);
+    if anim_count > 10 {
+        critical.push(if en {
+            format!("{anim_count} non-composited animations")
+        } else {
+            format!("{anim_count} nicht-composited Animationen")
+        });
+    }
+
+    if critical.is_empty() {
+        return base;
+    }
+
+    let mut positive: Vec<String> = Vec::new();
+    if p.vitals.cls.as_ref().is_some_and(|v| v.rating == "good") {
+        positive.push(
+            if en {
+                "layout stability (CLS)"
+            } else {
+                "Layout-Stabilität (CLS)"
+            }
+            .to_string(),
+        );
+    }
+    if p.vitals.tbt.as_ref().is_some_and(|v| v.rating == "good") {
+        positive.push(
+            if en {
+                "main-thread blocking (TBT)"
+            } else {
+                "Hauptthread-Blockierung (TBT)"
+            }
+            .to_string(),
+        );
+    }
+
+    let mut out = base;
+    if !out.is_empty() {
+        out.push(' ');
+    }
+    if en {
+        out.push_str(&format!(
+            "Critical here are {}.",
+            join_phrases(&critical, en)
+        ));
+        if !positive.is_empty() {
+            let verb = if positive.len() == 1 {
+                "remains"
+            } else {
+                "remain"
+            };
+            out.push_str(&format!(
+                " In contrast, {} {verb} unobtrusive.",
+                join_phrases(&positive, en)
+            ));
+        }
+    } else {
+        out.push_str(&format!(
+            "Kritisch sind hier {}.",
+            join_phrases(&critical, en)
+        ));
+        if !positive.is_empty() {
+            let verb = if positive.len() == 1 {
+                "bleibt"
+            } else {
+                "bleiben"
+            };
+            out.push_str(&format!(
+                " Im Kontrast dazu {verb} {} unauffällig.",
+                join_phrases(&positive, en)
+            ));
+        }
+    }
+    out
+}
+
 pub(super) fn build_module_details_from_normalized(
     i18n: &I18n,
     normalized: &AuditContext,
@@ -170,6 +325,8 @@ pub(super) fn build_module_details_from_normalized(
         } else {
             base_perf
         };
+        let perf_interpretation =
+            append_performance_qualifiers(perf_interpretation, p, normalized, en);
 
         let throttled_profiles: Vec<ThrottledPerfEntry> = normalized
             .raw_throttled_performance

--- a/src/output/builder/single/positive.rs
+++ b/src/output/builder/single/positive.rs
@@ -31,9 +31,9 @@ pub(super) fn derive_positive_aspects_from_normalized(
         positives.push(PositiveAspect {
             area: area_a11y,
             description: if en {
-                "Solid base quality with focused, prioritizable remaining items.".into()
+                "Stable base quality with focused, prioritizable remaining items.".into()
             } else {
-                "Solide Grundqualität mit gezielt priorisierbaren Restpunkten.".into()
+                "Stabile Grundqualität mit gezielt priorisierbaren Restpunkten.".into()
             },
         });
     }

--- a/src/output/explanations.rs
+++ b/src/output/explanations.rs
@@ -1415,3 +1415,27 @@ static EXPLANATIONS: &[(&str, RuleExplanation)] = &[
         },
     ),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #357: these rules carry their explanation under the
+    /// taxonomy key, so a lookup must resolve them and return a localized
+    /// (non-empty, distinct DE/EN) recommendation rather than a raw English fix.
+    #[test]
+    fn taxonomy_keyed_rules_have_localized_recommendation() {
+        for rule_id in [
+            "a11y.aria_hidden_focus.invalid",
+            "a11y.aria_prohibited_attr.invalid",
+        ] {
+            let expl = get_explanation(rule_id)
+                .unwrap_or_else(|| panic!("missing explanation for {rule_id}"));
+            let de = expl.recommendation_for("de");
+            let en = expl.recommendation_for("en");
+            assert!(!de.is_empty(), "{rule_id}: empty DE recommendation");
+            assert!(!en.is_empty(), "{rule_id}: empty EN recommendation");
+            assert_ne!(de, en, "{rule_id}: DE and EN recommendation identical");
+        }
+    }
+}

--- a/src/output/pdf/batch_report.rs
+++ b/src/output/pdf/batch_report.rs
@@ -29,34 +29,67 @@ pub(super) fn build_batch_assessment(
 ) -> String {
     let en = i18n.locale() == "en";
     let score = summary.average_score.round() as u32;
-    if dist.critical > 0 && score < 50 {
+    // Score band is the primary signal; severity only refines wording within a
+    // band. A low average must never yield a reassuring label (mirrors the
+    // single-report logic in builder/single/executive.rs, #355).
+    if score < 40 {
         if en {
             "Critical barriers — not WCAG conformant".to_string()
         } else {
             "Kritische Barrieren — nicht WCAG-konform".to_string()
         }
-    } else if dist.critical > 0 {
-        if en {
-            "Technically solid, but legally risky".to_string()
+    } else if score < 60 {
+        if dist.critical > 0 {
+            if en {
+                "Serious barriers — not WCAG conformant".to_string()
+            } else {
+                "Gravierende Barrieren — nicht WCAG-konform".to_string()
+            }
+        } else if en {
+            "Substantial accessibility gaps".to_string()
         } else {
-            "Technisch stabil, aber rechtlich riskant".to_string()
+            "Erhebliche Barrierefreiheitslücken".to_string()
         }
-    } else if dist.high > 0 {
-        if en {
-            "Good foundation, but not accessible".to_string()
+    } else if score < 75 {
+        if dist.critical > 0 {
+            if en {
+                "Usable, but legally risky".to_string()
+            } else {
+                "Nutzbar, aber rechtlich riskant".to_string()
+            }
+        } else if dist.high > 0 {
+            if en {
+                "Usable foundation, but not yet accessible".to_string()
+            } else {
+                "Nutzbare Basis, aber noch nicht barrierefrei".to_string()
+            }
+        } else if en {
+            "Needs improvement toward accessibility".to_string()
         } else {
-            "Gute Basis, aber nicht barrierefrei".to_string()
+            "Verbesserungswürdig auf dem Weg zur Barrierefreiheit".to_string()
         }
-    } else if score >= 85 {
-        if en {
-            "Largely accessible — polish".to_string()
+    } else if score < 90 {
+        if dist.critical > 0 {
+            if en {
+                "Technically stable, but legally risky".to_string()
+            } else {
+                "Technisch stabil, aber rechtlich riskant".to_string()
+            }
+        } else if dist.high > 0 {
+            if en {
+                "Good foundation, but not accessible".to_string()
+            } else {
+                "Gute Basis, aber nicht barrierefrei".to_string()
+            }
+        } else if en {
+            "Largely accessible — fine-tuning".to_string()
         } else {
             "Weitgehend barrierefrei — Feinschliff".to_string()
         }
     } else if en {
-        "Solid foundation with room to optimize".to_string()
+        "Largely accessible — polish".to_string()
     } else {
-        "Stabile Grundlage mit Optimierungspotenzial".to_string()
+        "Weitgehend barrierefrei — Feinschliff".to_string()
     }
 }
 

--- a/src/output/pdf/detail_modules.rs
+++ b/src/output/pdf/detail_modules.rs
@@ -1182,9 +1182,103 @@ pub(super) fn render_mobile(
     }
 
     for (cat, sev, msg) in &mobile.issues {
-        builder = builder.add_component(Finding::new(cat, map_severity(sev), msg));
+        let label = mobile_category_label(cat, i18n);
+        builder = builder.add_component(Finding::new(&label, map_severity(sev), msg));
     }
     builder
+}
+
+/// Maps a raw journey finding category (e.g. "HiddenFocusable") to a localized,
+/// human-readable title. Unknown categories fall back to a space-separated form
+/// of the PascalCase identifier so an internal enum name never reaches the
+/// report verbatim (#358).
+fn journey_category_label(category: &str, i18n: &I18n) -> String {
+    let en = i18n.locale() == "en";
+    let label = match category {
+        "TabOrder" => Some(if en { "Tab order" } else { "Tab-Reihenfolge" }),
+        "FocusTrap" => Some(if en { "Focus trap" } else { "Fokus-Falle" }),
+        "StateTransition" => Some(if en {
+            "State transition"
+        } else {
+            "Zustandswechsel"
+        }),
+        "FocusRestoration" => Some(if en {
+            "Focus restoration"
+        } else {
+            "Fokus-Wiederherstellung"
+        }),
+        "FormError" => Some(if en {
+            "Form error announcement"
+        } else {
+            "Formularfehler-Ansage"
+        }),
+        "SpaNavigation" => Some(if en {
+            "SPA navigation"
+        } else {
+            "SPA-Navigation"
+        }),
+        "HiddenFocusable" => Some(if en {
+            "Hidden focusable element"
+        } else {
+            "Verstecktes fokussierbares Element"
+        }),
+        "SkipLink" => Some(if en { "Skip link" } else { "Skip-Link" }),
+        "FocusIndicator" => Some(if en {
+            "Focus indicator"
+        } else {
+            "Fokus-Indikator"
+        }),
+        "MenuJourney" => Some(if en {
+            "Menu navigation"
+        } else {
+            "Menü-Navigation"
+        }),
+        "TabsJourney" => Some(if en {
+            "Tab navigation"
+        } else {
+            "Tab-Navigation"
+        }),
+        _ => None,
+    };
+    if let Some(label) = label {
+        return label.to_string();
+    }
+    // Fallback: split a PascalCase / snake_case identifier into words.
+    let mut out = String::new();
+    for (i, ch) in category.char_indices() {
+        if ch == '_' || ch == '-' {
+            out.push(' ');
+        } else if ch.is_uppercase() && i > 0 && !out.ends_with(' ') {
+            out.push(' ');
+            out.push(ch);
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Maps a raw mobile issue category (e.g. "touch_targets") to a localized,
+/// human-readable label. Unknown categories fall back to a title-cased form of
+/// the identifier so a snake_case key never reaches the report verbatim (#358).
+fn mobile_category_label(category: &str, i18n: &I18n) -> String {
+    let key = format!("mobile-cat-{category}");
+    let translated = i18n.t(&key);
+    if translated != key {
+        return translated;
+    }
+    category
+        .split(['_', '-'])
+        .filter(|w| !w.is_empty())
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 pub(super) fn render_ux(
@@ -1912,13 +2006,31 @@ pub(super) fn render_a11y_journey_findings(
         .with_level(2),
     );
 
-    let critical_count = findings
+    // Collapse identical journey findings (same journey, category, message and
+    // severity) into a single row with an occurrence count. Repeated identical
+    // entries otherwise read like a render-loop bug (#358). Distinct elements
+    // carry distinct messages and are never merged.
+    let mut deduped: Vec<(&crate::audit::normalized::InteractiveFinding, usize)> = Vec::new();
+    for f in findings {
+        if let Some(entry) = deduped.iter_mut().find(|(g, _)| {
+            g.journey == f.journey
+                && g.category == f.category
+                && g.message == f.message
+                && g.severity == f.severity
+        }) {
+            entry.1 += 1;
+        } else {
+            deduped.push((f, 1));
+        }
+    }
+
+    let critical_count = deduped
         .iter()
-        .filter(|f| f.severity == crate::taxonomy::Severity::Critical)
+        .filter(|(f, _)| f.severity == crate::taxonomy::Severity::Critical)
         .count();
-    let high_count = findings
+    let high_count = deduped
         .iter()
-        .filter(|f| f.severity == crate::taxonomy::Severity::High)
+        .filter(|(f, _)| f.severity == crate::taxonomy::Severity::High)
         .count();
     let overview = if critical_count > 0 {
         if en {
@@ -1944,12 +2056,12 @@ pub(super) fn render_a11y_journey_findings(
     } else if en {
         format!(
             "{} minor interactive issues — no critical or high barriers detected.",
-            findings.len()
+            deduped.len()
         )
     } else {
         format!(
             "{} kleinere interaktive Befunde — keine kritischen oder hohen Barrieren erkannt.",
-            findings.len()
+            deduped.len()
         )
     };
     builder = builder.add_component(if critical_count > 0 {
@@ -1960,27 +2072,32 @@ pub(super) fn render_a11y_journey_findings(
         Callout::success(&overview)
     });
 
-    let shown = findings.len().min(10);
-    for finding in &findings[..shown] {
+    let shown = deduped.len().min(10);
+    for (finding, count) in &deduped[..shown] {
         let sev = map_severity(&finding.severity);
         let body = if let Some(ref fix) = finding.fix_suggestion {
             format!("{} — {}", finding.message, fix)
         } else {
             finding.message.clone()
         };
-        let title = format!("[{}] {}", finding.journey, finding.category);
+        let label = journey_category_label(&finding.category, i18n);
+        let title = if *count > 1 {
+            format!("{label} (×{count})")
+        } else {
+            label
+        };
         builder = builder.add_component(Finding::new(&title, sev, &body));
     }
-    if findings.len() > 10 {
+    if deduped.len() > 10 {
         let more = if en {
             format!(
                 "{} additional interactive findings in the JSON report.",
-                findings.len() - 10
+                deduped.len() - 10
             )
         } else {
             format!(
                 "{} weitere interaktive Befunde im JSON-Report.",
-                findings.len() - 10
+                deduped.len() - 10
             )
         };
         builder = builder.add_component(Callout::info(&more));

--- a/src/output/pdf/diagnosis.rs
+++ b/src/output/pdf/diagnosis.rs
@@ -15,11 +15,9 @@ pub(super) fn render_diagnosis_section(
 
     builder = builder.add_component(Section::new(&diagnosis.section_title).with_level(2));
 
-    // Pattern overview — label + description
-    let pattern_intro = format!(
-        "{}: {}",
-        diagnosis.pattern_label, diagnosis.pattern_description
-    );
+    // Pattern overview — label is the callout title; the body carries only the
+    // description so the label is not repeated as a prefix in the body text.
+    let pattern_intro = diagnosis.pattern_description.clone();
     let callout = if diagnosis.is_systematic {
         Callout::warning(&pattern_intro).with_title(&diagnosis.pattern_label)
     } else {

--- a/src/output/pdf/mod.rs
+++ b/src/output/pdf/mod.rs
@@ -558,10 +558,11 @@ fn build_single_report(
     // SECTIONS 4 + 5 + 5b + 6+ (Standard / Technical only)
     // ─────────────────────────────────────────────────────────────────
     builder = render_action_plan(builder, &vm, &i18n);
+    // Recommended next steps belong with the action plan at the end of Part 1,
+    // not buried after the least actionable technical modules (#362).
+    builder = render_next_steps_single(builder, &vm);
     builder = render_tech_entry(builder, &vm, &i18n);
     builder = render_tech_details(builder, &vm, report, &i18n);
-
-    builder = render_next_steps_single(builder, &vm);
 
     let built_report = builder.build();
     Ok((engine, built_report))

--- a/src/output/pdf/modules.rs
+++ b/src/output/pdf/modules.rs
@@ -75,8 +75,8 @@ pub(super) fn build_was_jetzt_tun_table(vm: &ReportViewModel) -> WasJetztTunCont
     }
 
     let table_title = match selected.len() {
-        1 => "Maßnahmenplan (1 Maßnahme) — Executive View".to_string(),
-        n => format!("Maßnahmenplan ({n} Maßnahmen) — Executive View"),
+        1 => "Maßnahmenplan (1 Maßnahme)".to_string(),
+        n => format!("Maßnahmenplan ({n} Maßnahmen)"),
     };
 
     let mut table = AuditTable::new(vec![

--- a/src/output/pdf/single_report.rs
+++ b/src/output/pdf/single_report.rs
@@ -267,7 +267,7 @@ pub(super) fn render_tech_details(
                     .with_level(2),
             );
 
-            for criticality in &vm.findings.by_tier {
+            for (tier_idx, criticality) in vm.findings.by_tier.iter().enumerate() {
                 let tier_summary = if en {
                     format!(
                         "{} finding(s) — {} occurrence(s) total. {}",
@@ -283,7 +283,13 @@ pub(super) fn render_tech_details(
                         criticality.intro
                     )
                 };
-                builder = builder.add_component(PageBreak::new()).add_component(
+                // Keep the first tier on the same page as the section divider so
+                // the divider page is not nearly empty (#365); break only before
+                // subsequent tiers.
+                if tier_idx > 0 {
+                    builder = builder.add_component(PageBreak::new());
+                }
+                builder = builder.add_component(
                     SectionHeaderSplit::new(&criticality.label, &tier_summary)
                         .with_eyebrow(&criticality.eyebrow)
                         .with_level(2),
@@ -372,8 +378,10 @@ pub(super) fn render_tech_details(
         );
     }
 
-    // Appendix — full violations list, conclusion of Part 2 (#246).
-    {
+    // Appendix — full violations list, conclusion of Part 2 (#246). Only render
+    // the section header when there are violations to list; otherwise it
+    // promises a list that never appears (#364).
+    if vm.appendix.has_violations {
         let (appendix_title, appendix_intro) = if en {
             (
                 "Complete Findings List",
@@ -390,9 +398,7 @@ pub(super) fn render_tech_details(
                 .with_eyebrow(if en { "APPENDIX" } else { "ANHANG" })
                 .with_level(2),
         );
-    }
 
-    if vm.appendix.has_violations {
         builder = builder.add_component(build_cli_snapshot_table(vm, i18n));
 
         // JSON hint in appendix (#219)
@@ -593,7 +599,10 @@ pub(super) fn render_tech_details(
                 },
             )
             .with_eyebrow(if en { "ANALYSIS" } else { "ANALYSE" })
-            .with_level(2),
+            // Sub-divider that groups the technical modules — must sit one level
+            // above the L2 module headings it introduces, otherwise two equal
+            // L2 headings collide with no content between them (#363).
+            .with_level(1),
         );
     }
     if let Some(ref perf) = vm.module_details.performance {

--- a/tests/module_fixtures.rs
+++ b/tests/module_fixtures.rs
@@ -69,8 +69,8 @@ fn ax_tree_rich_page() -> AXTree {
     // backfill parent_id so AXTree::iter() (which walks the tree) yields
     // every node.
     let mut nodes = nodes;
-    for i in 1..nodes.len() {
-        nodes[i].parent_id = Some("1".to_string());
+    for node in nodes.iter_mut().skip(1) {
+        node.parent_id = Some("1".to_string());
     }
     AXTree::from_nodes(nodes)
 }


### PR DESCRIPTION
Behebt alle 13 offenen Report-Quality-Issues aus dem Review vom 2026-05-30.

## Wording & Scoring
- **#355** Bewertungs-Label score-band-primär (Single + Batch) — „Gute Basis" erst ab Score ≥ 60, Kritisch-Band ab < 40
- **#356** Füllwort „solide/solid" aus allen Prosa-Strings entfernt; Verdict-Tier stuft bei `legal_flags > 0` ab (kein beruhigendes Tier bei rechtlichem Risiko). Zertifikat-Notenstufe „SOLIDE" (eigene Taxonomie) bewusst unangetastet
- **#359** Diagnose-Callout-Body wiederholt den Titel nicht mehr
- **#360** Anteil-Prozent einmal aus `dominant_issue.share_pct` berechnet, an beiden Stellen identisch
- **#367** Performance-Interpretation benennt schwache Metriken (DOM-Komplexität, throttled LCP, Render-Blocking, unminifizierte Assets, nicht-composited Animationen) und nennt CLS/TBT als Kontrast

## i18n & Roh-Identifier
- **#357** Ursache: Erklärungs-Lookup per `wcag_criterion` statt `rule_id` → deutsche Texte in `explanations.rs` unerreichbar. Lookup-Fallback auf `rule_id` korrigiert (+ Regressionstest)
- **#358** FTL-Key `seo-technical-issues-title` ergänzt · Mobile-/Journey-Kategorien lokalisiert · 10×-Journey-Duplikate dedupliziert mit „(×N)" · internen Suffix „— Executive View" entfernt

## Layout & Struktur
- **#361** Doppelter Titel „Technisches SEO" differenziert (KV-Liste → „Technische SEO-Signale")
- **#362** „Empfohlene nächste Schritte" vor die technischen Modul-Details gezogen
- **#363** „Technik & Qualität"-Divider auf L1 angehoben (keine zwei gleichrangigen L2 mehr)
- **#364** Appendix „Vollständige Fundstellen" rendert Header nur noch bei vorhandenen Verstößen
- **#365** Erstes Kritikalitäts-Tier bleibt auf der Divider-Seite (keine fast leere Seite)

## renderreport
- **#366** Engine-Fix: Breakable-Komponenten (lange Tabellen) werden nicht mehr in den `breakable: false`-Block der KeepWithNext-Paarung getrappt → Tabellen brechen sauber auf Folgeseiten um. Veröffentlicht als **renderreport 0.2.20**; Dependency hier aktualisiert

## Validierung
- `cargo check --all-features` ✓ (pre-push-Hook)
- `cargo clippy --all-features` — keine neuen Warnungen
- `cargo test --all-features` ✓ 863 Tests grün (inkl. PDF-Smoke + „no raw typst syntax")

Closes #355, #356, #357, #358, #359, #360, #361, #362, #363, #364, #365, #366, #367