### PR TITLE
Cache-Korrektheit: --reuse-cache lädt wieder und rendert originalgetreu (#404, #405)

### DIFF
--- a/src/audit/artifacts.rs
+++ b/src/audit/artifacts.rs
@@ -24,6 +24,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::accessibility::AXTree;
 use crate::audit::normalized::NormalizedReport;
@@ -88,6 +89,12 @@ pub struct AuditArtifacts {
     pub fetch: FetchArtifact,
     pub snapshot: SnapshotArtifact,
     pub audit: NormalizedReport,
+    /// The complete `AuditReport` (screenshots stripped), persisted so a cache
+    /// hit can render every module section faithfully instead of through the
+    /// lossy `to_audit_report` reconstruction. `None` for legacy entries
+    /// written before this field existed — those fall back to `to_audit_report`.
+    #[serde(default)]
+    pub report: Option<AuditReport>,
     pub content_hash: String,
     pub meta: CacheMeta,
 }
@@ -110,6 +117,9 @@ pub fn save_artifacts(url: &str, wcag_level: &str, artifacts: &AuditArtifacts) -
         dir.join("audit.json"),
         serde_json::to_vec_pretty(&artifacts.audit)?,
     )?;
+    if let Some(ref report) = artifacts.report {
+        fs::write(dir.join("report.json"), serde_json::to_vec_pretty(report)?)?;
+    }
 
     let meta = CacheMeta {
         auditmysite_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -132,20 +142,50 @@ pub fn load_artifacts(url: &str) -> Result<Option<AuditArtifacts>> {
     let fetch_path = dir.join("fetch.json");
     let snapshot_path = dir.join("snapshot.json");
     let audit_path = dir.join("audit.json");
+    let report_path = dir.join("report.json");
     let meta_path = dir.join("meta.json");
 
     if !fetch_path.exists() || !snapshot_path.exists() || !audit_path.exists() {
         return Ok(None);
     }
 
-    let fetch: FetchArtifact = serde_json::from_slice(&fs::read(fetch_path)?)?;
-    let snapshot: SnapshotArtifact = serde_json::from_slice(&fs::read(snapshot_path)?)?;
-    let audit: NormalizedReport = serde_json::from_slice(&fs::read(audit_path)?)?;
+    // A truncated or otherwise corrupt cache entry must not abort the run — treat
+    // any read/parse failure as a cache miss so the caller falls back to a fresh
+    // audit (#405).
+    macro_rules! load_or_miss {
+        ($path:expr, $ty:ty) => {
+            match fs::read(&$path)
+                .map_err(|e| e.to_string())
+                .and_then(|bytes| serde_json::from_slice::<$ty>(&bytes).map_err(|e| e.to_string()))
+            {
+                Ok(value) => value,
+                Err(e) => {
+                    warn!(
+                        "Cache entry {} is unreadable ({}); ignoring and running fresh",
+                        $path.display(),
+                        e
+                    );
+                    return Ok(None);
+                }
+            }
+        };
+    }
+
+    let fetch: FetchArtifact = load_or_miss!(fetch_path, FetchArtifact);
+    let snapshot: SnapshotArtifact = load_or_miss!(snapshot_path, SnapshotArtifact);
+    let audit: NormalizedReport = load_or_miss!(audit_path, NormalizedReport);
     let content_hash = content_hash(&snapshot);
+
+    // Optional full report (absent for legacy entries → to_audit_report fallback).
+    let report: Option<AuditReport> = if report_path.exists() {
+        Some(load_or_miss!(report_path, AuditReport))
+    } else {
+        None
+    };
 
     // Load meta if present; generate a default for entries written before meta.json existed.
     let meta = if meta_path.exists() {
-        serde_json::from_slice(&fs::read(meta_path)?)?
+        load_or_miss!(meta_path, CacheMeta)
     } else {
         CacheMeta {
             auditmysite_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -160,6 +200,7 @@ pub fn load_artifacts(url: &str) -> Result<Option<AuditArtifacts>> {
         fetch,
         snapshot,
         audit,
+        report,
         content_hash,
         meta,
     }))
@@ -280,6 +321,21 @@ pub fn to_audit_report(artifacts: &AuditArtifacts, locale: &str) -> AuditReport 
     }
 
     report
+}
+
+/// Rebuild the `#[serde(skip)]` fields a cached `AuditReport` needs for
+/// rendering but that are never persisted. The screen-reader audit is a cheap
+/// structural pass over the cached AXTree, so it is recomputed exactly as a
+/// fresh run (and `to_audit_report`) does. No-op when the field is already set.
+pub fn hydrate_cached_report(report: &mut AuditReport, snapshot: &SnapshotArtifact, locale: &str) {
+    if report.screen_reader_audit.is_none() {
+        report.screen_reader_audit = Some(crate::screen_reader::build_sr_audit_report(
+            &report.url,
+            report.timestamp,
+            &snapshot.ax_tree,
+            locale,
+        ));
+    }
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────

--- a/src/audit/batch.rs
+++ b/src/audit/batch.rs
@@ -226,7 +226,12 @@ async fn audit_url_with_pool(
             let pooled_page = pool.acquire().await?;
             let page = pooled_page.page()?;
             // audit_page handles viewport switching and navigation internally
-            let report = audit_page(page, url, config, pool.browser()).await?;
+            let (report, snapshot) = audit_page(page, url, config, pool.browser()).await?;
+            // Batch applies no canonical-performance pass, so the report is
+            // final here — persist it (audit_page no longer persists itself).
+            if config.persist_artifacts {
+                crate::audit::pipeline::persist_artifacts(url, config, &snapshot, &report);
+            }
             Ok::<AuditReport, AuditError>(report)
         })
         .await

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -20,8 +20,8 @@ pub mod summary;
 pub mod verdict;
 
 pub use artifacts::{
-    cache_matches_signature, content_hash, load_artifacts, save_artifacts, to_audit_report,
-    AuditArtifacts, FetchArtifact, SnapshotArtifact,
+    cache_matches_signature, content_hash, hydrate_cached_report, load_artifacts, save_artifacts,
+    to_audit_report, AuditArtifacts, FetchArtifact, SnapshotArtifact,
 };
 pub use baseline::{Baseline, BaselineDiff, BaselineViolation, WaivedViolation};
 pub use batch::{

--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -64,7 +64,7 @@ pub struct NormalizedReport {
     #[serde(default)]
     pub has_screenshots: bool,
     /// Per-viewport scores from dual-pass audit (70 % mobile / 30 % desktop).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub viewport_scores: Option<ViewportScores>,
     /// How `overall_score` was computed: `"module_weighted"` (standard) or
     /// `"viewport_weighted"` (dual-pass: 70 % mobile + 30 % desktop + 10 % security).
@@ -72,7 +72,7 @@ pub struct NormalizedReport {
     /// Exact inputs used to produce `overall_score`.
     /// Present only for `viewport_weighted`; absent for `module_weighted` (module
     /// `weight_pct` values are already exact in that case).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub score_breakdown: Option<ScoreBreakdown>,
 
     /// Findings produced by the Accessibility-Journey-Layer (Phase 1+).
@@ -98,7 +98,7 @@ pub struct NormalizedReport {
     /// Pre-computed interpretation (evaluation texts, score bands). Always
     /// present after `normalize()`. Skipped in the `#[serde(skip)]` raw fields
     /// below so it IS serialized — consumers can read it without recomputing.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interpretation: Option<Interpretation>,
 }
 
@@ -191,10 +191,10 @@ pub struct NormalizedFinding {
     /// Schweregrad
     pub severity: Severity,
     /// Auswirkung auf den Nutzer
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub user_impact: String,
     /// Technische Auswirkung
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub technical_impact: String,
     /// Strukturierter Score-Impact
     pub score_impact: ScoreImpactData,
@@ -284,9 +284,9 @@ impl Default for ReportVisibilityData {
 pub struct OccurrenceDetail {
     pub node_id: String,
     pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selector: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fix_suggestion: Option<String>,
     /// Raw outer HTML of the affected element
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -463,10 +463,10 @@ pub struct ScoreBreakdown {
     /// Weight given to the viewport blend in the final formula (always 90 when security present)
     pub viewport_blend_weight_pct: u32,
     /// Security score after vulnerable-library penalty
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_score: Option<u32>,
     /// Weight given to security in the final formula (always 10 when security present)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_weight_pct: Option<u32>,
 }
 

--- a/src/audit/pipeline.rs
+++ b/src/audit/pipeline.rs
@@ -75,8 +75,10 @@ async fn set_viewport(page: &Page, viewport: Viewport) -> Result<()> {
 // ── Snapshot data ─────────────────────────────────────────────────────────────
 
 /// Extracted snapshot data from a loaded page (one viewport pass).
+/// Captured page snapshot for one audit. Returned by `audit_page` so the caller
+/// can persist the cache entry after post-processing; fields stay crate-internal.
 #[derive(Debug, Clone)]
-struct SnapshotData {
+pub struct SnapshotData {
     ax_tree: AXTree,
     performance: Option<PerformanceResults>,
     seo: Option<SeoAnalysis>,
@@ -181,7 +183,7 @@ impl PipelineConfig {
     /// (timeout, verbosity, persistence, screenshot capture).
     pub fn audit_signature(&self) -> String {
         format!(
-            "v={};level={};perf={};seo={};sec={};mobile={};dark={};stack={};consent={};interactive={:?};journey_budget_ms={}",
+            "v={};level={};perf={};seo={};sec={};mobile={};dark={};stack={};consent={};interactive={:?};journey_budget_ms={};lang={};semantic={}",
             env!("CARGO_PKG_VERSION"),
             self.wcag_level,
             self.check_performance as u8,
@@ -193,6 +195,8 @@ impl PipelineConfig {
             self.dismiss_consent as u8,
             self.interactive,
             self.journey_budget_ms,
+            self.lang,
+            self.semantic_eval.enabled as u8,
         )
     }
 }
@@ -297,7 +301,7 @@ pub async fn run_single_audit(
     let page = browser.new_page().await?;
     debug!("Created new page");
 
-    let mut report = audit_page(&page, url, config, browser).await?;
+    let (mut report, snapshot) = audit_page(&page, url, config, browser).await?;
 
     if config.check_performance {
         let (throttled, canonical) =
@@ -306,6 +310,12 @@ pub async fn run_single_audit(
         if let Some((vitals, score)) = canonical {
             apply_canonical_perf(&mut report, vitals, score);
         }
+    }
+
+    // Persist now that the report is final (post canonical-performance), so a
+    // cache hit renders identically to this fresh run (#404).
+    if config.persist_artifacts {
+        persist_artifacts(url, config, &snapshot, &report);
     }
 
     let duration = start_time.elapsed();
@@ -321,12 +331,16 @@ pub async fn run_single_audit(
 ///
 /// Handles its own viewport switching and URL navigation internally.
 /// Callers must supply `browser` for re-navigation between passes.
+///
+/// Returns the report together with the captured `SnapshotData` so the caller
+/// can persist the cache entry *after* any post-processing (e.g. the canonical
+/// performance pass), keeping the cached report identical to a fresh render.
 pub async fn audit_page(
     page: &Page,
     url: &str,
     config: &PipelineConfig,
     browser: &BrowserManager,
-) -> Result<AuditReport> {
+) -> Result<(AuditReport, SnapshotData)> {
     let start_time = Instant::now();
 
     // Enable bypassing CSP on the page
@@ -571,11 +585,11 @@ pub async fn audit_page(
     let advisory = crate::semantic_eval::run(&config.semantic_eval, &primary_snap.ax_tree).await;
     report.advisory_findings = advisory;
 
-    if config.persist_artifacts {
-        persist_artifacts(url, config, &primary_snap, &report);
-    }
-
-    Ok(report)
+    // Persistence is deferred to the caller: the single-page path applies the
+    // canonical (LhMobile) performance pass *after* audit_page returns, so
+    // persisting here would cache a pre-canonical report that differs from a
+    // fresh render (#404). The caller persists once the report is final.
+    Ok((report, primary_snap))
 }
 
 // ── Score helpers ─────────────────────────────────────────────────────────────
@@ -1120,7 +1134,7 @@ fn apply_canonical_perf(
     }
 }
 
-fn persist_artifacts(
+pub(crate) fn persist_artifacts(
     url: &str,
     config: &PipelineConfig,
     snapshot: &SnapshotData,
@@ -1143,6 +1157,11 @@ fn persist_artifacts(
         content_hash: hash.clone(),
         audit_signature: config.audit_signature(),
     };
+    // Persist the full report so cache hits render every module faithfully.
+    // Screenshots reference temp files that won't exist on reload, so strip them.
+    let mut report_for_cache = report.clone();
+    report_for_cache.page_screenshots = None;
+
     let artifacts = AuditArtifacts {
         fetch: FetchArtifact {
             requested_url: url.to_string(),
@@ -1153,6 +1172,7 @@ fn persist_artifacts(
         },
         snapshot: snapshot_artifact,
         audit: normalized,
+        report: Some(report_for_cache),
         content_hash: hash,
         meta,
     };
@@ -1320,6 +1340,17 @@ mod tests {
         // Interactive budget changes the possible journey findings.
         let mut other = test_pipeline_config();
         other.journey_budget_ms += 1;
+        assert_ne!(base_sig, other.audit_signature());
+
+        // Output language drives locale-dependent detection/text in the cached
+        // report, so it must invalidate the cache (#405).
+        let mut other = test_pipeline_config();
+        other.lang = "en".to_string();
+        assert_ne!(base_sig, other.audit_signature());
+
+        // Semantic eval adds advisory findings to the cached report (#405).
+        let mut other = test_pipeline_config();
+        other.semantic_eval.enabled = !base.semantic_eval.enabled;
         assert_ne!(base_sig, other.audit_signature());
     }
 

--- a/src/cli/runners.rs
+++ b/src/cli/runners.rs
@@ -14,8 +14,9 @@ use tracing::info;
 use auditmysite::audit::normalize;
 use auditmysite::audit::{
     analyze_crawl_links, cache_matches_signature, compute_batch_verdict, compute_verdict,
-    crawl_site, load_artifacts, parse_sitemap, read_url_file, run_concurrent_batch,
-    run_single_audit, to_audit_report, BatchConfig, CrawlResult, PipelineConfig, Verdict,
+    crawl_site, hydrate_cached_report, load_artifacts, parse_sitemap, read_url_file,
+    run_concurrent_batch, run_single_audit, to_audit_report, BatchConfig, CrawlResult,
+    PipelineConfig, Verdict,
 };
 use auditmysite::browser::{BrowserManager, BrowserOptions};
 use auditmysite::cli::{Args, OutputFormat, RequestMode};
@@ -71,36 +72,41 @@ pub async fn run_single_mode(
                     );
                 }
 
+                let verdict_cfg = config
+                    .as_ref()
+                    .map(|c| c.effective_verdict_config())
+                    .unwrap_or_default();
+                // The verdict always derives from the stored NormalizedReport,
+                // so it is identical regardless of --format (#404).
+                let verdict_result = compute_verdict(&cached.audit, &verdict_cfg);
+
+                // Prefer the full cached report so every module section renders
+                // faithfully; fall back to the lossy reconstruction only for
+                // legacy entries written before report.json existed (#404).
+                let mut report = cached
+                    .report
+                    .clone()
+                    .unwrap_or_else(|| to_audit_report(&cached, &args.lang));
+                // screen_reader_audit is #[serde(skip)] and therefore absent from
+                // the persisted report — rebuild it from the cached AXTree so the
+                // cached report renders the same sections as a fresh run (#404).
+                hydrate_cached_report(&mut report, &cached.snapshot, &args.lang);
+
                 match args.effective_format() {
                     OutputFormat::Json => {
                         let output = format_json_cached(&cached.audit, true)?;
                         output_text(&output, &args.output, "JSON", args.quiet)?;
-                        let report = to_audit_report(&cached, &args.lang);
                         output_screen_reader_sidecar(&report, args)?;
-                        let verdict_cfg = config
-                            .as_ref()
-                            .map(|c| c.effective_verdict_config())
-                            .unwrap_or_default();
-                        let verdict_result = compute_verdict(&cached.audit, &verdict_cfg);
-                        print_verdict(&verdict_result, args.quiet);
-                        return Ok(verdict_result.verdict);
                     }
                     OutputFormat::Table
                     | OutputFormat::Pdf
                     | OutputFormat::Ai
                     | OutputFormat::Summary => {
-                        let report = to_audit_report(&cached, &args.lang);
-                        output_single_report(&report, args, None)?;
-                        let normalized = normalize(&report).normalized;
-                        let verdict_cfg = config
-                            .as_ref()
-                            .map(|c| c.effective_verdict_config())
-                            .unwrap_or_default();
-                        let verdict_result = compute_verdict(&normalized, &verdict_cfg);
-                        print_verdict(&verdict_result, args.quiet);
-                        return Ok(verdict_result.verdict);
+                        output_single_report(&report, args, Some(&verdict_result))?;
                     }
                 }
+                print_verdict(&verdict_result, args.quiet);
+                return Ok(verdict_result.verdict);
             }
             Some(_) if !args.quiet => {
                 println!(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -104,7 +104,7 @@ async fn test_perfect_page_scores_high() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 
@@ -143,7 +143,7 @@ async fn test_many_violations_page_scores_low() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 
@@ -184,7 +184,7 @@ async fn test_full_audit_with_all_modules() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &config, &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &config, &manager)
         .await
         .expect("Audit failed");
 
@@ -225,7 +225,7 @@ async fn test_output_formats() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 
@@ -274,7 +274,7 @@ async fn test_mobile_issues_detected() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &config, &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &config, &manager)
         .await
         .expect("Audit failed");
 
@@ -314,7 +314,7 @@ async fn test_modern_contrast_resolution() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 
@@ -389,7 +389,7 @@ async fn test_image_contrast_pixel_sampling() {
         .await
         .expect("Navigation failed");
 
-    let report = audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 
@@ -511,7 +511,7 @@ async fn test_catalog_driven_audit_complete_structure() {
         .await
         .expect("Navigation failed");
 
-    let report = auditmysite::audit_page(&page, &url, &config, &manager)
+    let (report, _snapshot) = auditmysite::audit_page(&page, &url, &config, &manager)
         .await
         .expect("Audit failed");
 
@@ -553,7 +553,7 @@ async fn test_partial_module_failure_does_not_abort_audit() {
         .await
         .expect("Navigation failed");
 
-    let report = auditmysite::audit_page(&page, &url, &config, &manager)
+    let (report, _snapshot) = auditmysite::audit_page(&page, &url, &config, &manager)
         .await
         .expect("Audit must succeed even when sub-analyses fail");
 
@@ -576,13 +576,13 @@ async fn test_sequential_two_url_audit() {
 
     let page1 = manager.new_page().await.expect("page 1 failed");
     manager.navigate(&page1, &url1).await.expect("nav 1 failed");
-    let report1 = auditmysite::audit_page(&page1, &url1, &default_config(), &manager)
+    let (report1, _snapshot) = auditmysite::audit_page(&page1, &url1, &default_config(), &manager)
         .await
         .expect("audit 1 failed");
 
     let page2 = manager.new_page().await.expect("page 2 failed");
     manager.navigate(&page2, &url2).await.expect("nav 2 failed");
-    let report2 = auditmysite::audit_page(&page2, &url2, &default_config(), &manager)
+    let (report2, _snapshot) = auditmysite::audit_page(&page2, &url2, &default_config(), &manager)
         .await
         .expect("audit 2 failed");
 
@@ -610,7 +610,7 @@ async fn test_catalog_audit_json_envelope_v2() {
         .await
         .expect("Navigation failed");
 
-    let report = auditmysite::audit_page(&page, &url, &default_config(), &manager)
+    let (report, _snapshot) = auditmysite::audit_page(&page, &url, &default_config(), &manager)
         .await
         .expect("Audit failed");
 

--- a/tests/report_consistency_tests.rs
+++ b/tests/report_consistency_tests.rs
@@ -710,6 +710,35 @@ fn test_risk_critical_with_level_a_violations() {
 }
 
 #[test]
+fn normalized_report_survives_cache_round_trip() {
+    // The --reuse-cache path serializes the NormalizedReport to audit.json and
+    // deserializes it on a cache hit. Every field skipped when empty/None must
+    // carry #[serde(default)] or the round-trip fails and the cache is unusable
+    // (#405). A full round-trip catches absent Option blocks (viewport_scores,
+    // interpretation, …).
+    let report = make_full_report();
+    let normalized = normalize(&report).normalized;
+    let json = serde_json::to_string(&normalized).expect("serialize NormalizedReport");
+    let _back: auditmysite::audit::normalized::NormalizedReport =
+        serde_json::from_str(&json).expect("NormalizedReport must round-trip through JSON");
+
+    // Findings with empty user_impact/technical_impact (e.g. SEO findings) skip
+    // those keys; deserialization must default them rather than error.
+    let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    if let Some(findings) = v.get_mut("findings").and_then(|f| f.as_array_mut()) {
+        for f in findings.iter_mut() {
+            if let Some(obj) = f.as_object_mut() {
+                obj.remove("user_impact");
+                obj.remove("technical_impact");
+            }
+        }
+    }
+    let stripped = serde_json::to_string(&v).unwrap();
+    let _back2: auditmysite::audit::normalized::NormalizedReport = serde_json::from_str(&stripped)
+        .expect("findings with absent user_impact/technical_impact must deserialize");
+}
+
+#[test]
 fn test_risk_low_without_violations() {
     let report = AuditReport::new(
         "https://example.com".to_string(),


### PR DESCRIPTION
Behebt #404 und #405 — plus zwei dabei aufgedeckte latente Bugs, die den Cache faktisch unbrauchbar machten.

## Wurzel-Bug (unsichtbar, weil der Cache nie lud)
`NormalizedFinding.user_impact`/`technical_impact` und mehrere `Option`-Blöcke nutzten `skip_serializing_if` **ohne** `#[serde(default)]`. Sobald ein Feld leer/abwesend war (z. B. SEO-Findings), schlug die Deserialisierung von `audit.json` fehl — und `load_artifacts(url)?` brach den **ganzen Run** ab. `#[serde(default)]` über `NormalizedReport` ergänzt; Round-Trip-Test hinzugefügt.

## #404 — verlustfreie Rekonstruktion & format-stabiles Verdikt
- **Lossy:** `to_audit_report` verwarf ux/journey/dark_mode/ai_visibility/content_visibility/tech_stack/patterns/best_practices. Jetzt wird der **volle `AuditReport`** persistiert (`report.json`, Screenshots gestrippt) und Cache-Hits rendern daraus. Die `#[serde(skip)]`-Screenreader-Analyse wird via `hydrate_cached_report` aus dem gecachten AXTree neu gebaut. Legacy-Einträge fallen auf `to_audit_report` zurück.
- **Format-abhängiges Verdikt:** das Verdikt leitet sich jetzt in **allen** Formaten aus dem gespeicherten `NormalizedReport` ab.

## Pre-Canonical-Persistenz (dabei entdeckt)
`persist_artifacts` lief in `audit_page` — **vor** der kanonischen LhMobile-Performance-Adoption in `run_single_audit`. Der Cache speicherte einen Pre-Canonical-Report (abweichende Perf-Werte ggü. fresh). `audit_page` gibt jetzt den Snapshot zurück; der Aufrufer persistiert, sobald der Report final ist. Empirisch bestätigt: cached Perf-Sektion == fresh (DOM 28931, identische CWV).

## #405 — Signatur & Robustheit
- `audit_signature` enthält jetzt `lang` + `semantic_eval.enabled`.
- Korrupte/abgeschnittene Cache-Dateien → Cache-Miss mit Warnung statt Run-Abbruch.

## Bekannte, dokumentierte Cache-Limits
- Device-Preview-Screenshots werden nicht gecacht (Temp-Dateien).
- Der ergänzende Desktop/Mobile-CWV-Detailblock fehlt im Cache (`DualViewportResults` ist bewusst nicht serialisierbar).

## Validierung
`cargo test --all-features` + `cargo clippy --all-features` grün; PDF-Tests single-threaded grün. Empirisch (casoon.de): Cache-Hit lädt, rendert alle Modul-Sektionen inkl. Screenreader, Perf stimmt mit fresh überein, keine Warnungen. Neue Tests: `normalized_report_survives_cache_round_trip`, Signatur-Coverage für lang/semantic.