### PR TITLE
Report-Qualität: 'keine Auffälligkeiten'-Hinweis statt stiller leerer Sektionen (#446)

### DIFF
--- a/locales/de/report.ftl
+++ b/locales/de/report.ftl
@@ -588,6 +588,7 @@ pdf-seo-ie-displayed = Angezeigt
 pdf-serp-summary = { $total } Signale geprüft — { $pass } OK, { $warning } Warnungen, { $fail } Fehler.
 pdf-serp-category = Kategorie
 pdf-serp-rich-results-text = Rich-Result-Typen möglich: { $types }
+pdf-section-clean = Im geprüften Umfang keine Auffälligkeiten festgestellt.
 pdf-ph-issue = Problem
 pdf-ph-w3c-title = W3C HTML Validator
 pdf-ph-www-title = www-Konsolidierung

--- a/locales/en/report.ftl
+++ b/locales/en/report.ftl
@@ -588,6 +588,7 @@ pdf-seo-ie-displayed = Displayed
 pdf-serp-summary = { $total } signals checked — { $pass } OK, { $warning } warnings, { $fail } failures.
 pdf-serp-category = Category
 pdf-serp-rich-results-text = Rich result types possible: { $types }
+pdf-section-clean = No issues found within the audited scope.
 pdf-ph-issue = Issue
 pdf-ph-w3c-title = W3C HTML validator
 pdf-ph-www-title = www consolidation

--- a/src/output/pdf/detail_modules.rs
+++ b/src/output/pdf/detail_modules.rs
@@ -810,6 +810,10 @@ pub(super) fn render_seo(
         }
     }
 
+    if seo.meta_issues.is_empty() && seo.technical_issues.is_empty() {
+        builder = builder.add_component(clean_section_note(i18n));
+    }
+
     builder
 }
 
@@ -869,12 +873,28 @@ pub(super) fn render_serp(
     builder
 }
 
+/// A neutral per-section line shown when a module produced no findings, so a
+/// reader can distinguish "checked and clean" from "not checked" instead of the
+/// section silently collapsing to nothing (#446).
+fn clean_section_note(i18n: &I18n) -> Label {
+    Label::new(format!("ℹ {}", i18n.t("pdf-section-clean")))
+        .with_size("10.5pt")
+        .with_color("#475569")
+}
+
 pub(super) fn render_page_health(
     mut builder: renderreport::engine::ReportBuilder,
     ph: &crate::output::report_model::PageHealthPresentation,
     i18n: &I18n,
 ) -> renderreport::engine::ReportBuilder {
     builder = builder.add_component(Section::new(i18n.t("section-page-health")).with_level(3));
+
+    // No health issues → state it explicitly (reference data like URL analysis
+    // may still follow), so "checked and clean" reads differently from "not
+    // checked" (#446).
+    if ph.issues.is_empty() {
+        builder = builder.add_component(clean_section_note(i18n));
+    }
 
     // Issues table (if any)
     if !ph.issues.is_empty() {
@@ -1289,6 +1309,9 @@ pub(super) fn render_security(
         builder = builder.add_component(kv);
     }
 
+    if sec.issues.is_empty() {
+        builder = builder.add_component(clean_section_note(i18n));
+    }
     for (title, sev, msg) in &sec.issues {
         builder = builder.add_component(Finding::new(title, map_severity(sev), msg));
     }


### PR DESCRIPTION
Behebt #446 — gut bewertete Seiten wirkten „leer", weil Detailsektionen ihre Findings nur bedingt (`if !empty`, ohne `else`) rendern: ohne Findings blieb nur eine ScoreCard, und der Kunde konnte „geprüft & sauber" nicht von „nicht geprüft" unterscheiden.

## Änderung
**Security**, **SEO** und **Page Health** geben jetzt eine neutrale Bestätigungszeile aus, wenn ihre Findings-Sammlung leer ist:
- DE: „Im geprüften Umfang keine Auffälligkeiten festgestellt."
- EN: „No issues found within the audited scope."

So ergibt sich pro Sektion ein konsistentes Signal:
- Sektion fehlt → nicht geprüft (Modul aus)
- Bestätigungszeile → geprüft, sauber
- Findings → geprüft, mit Befunden

## Bewusst unverändert
Die High-Score-Module **Source Quality / AI Visibility / Best Practices** (Score ≥80) rendern bereits einen Erfolgs-Callout, der genau diese Pro-Sektion-Bestätigung leistet — gemäß der gewählten Granularität (pro Sektion, nicht pro Sub-Block) bleiben sie wie sie sind.

Performance wurde nicht angefasst: die Sektion zeigt immer Core Web Vitals + Viewport-Scorecards, wirkt also nie „leer".

## Validierung
`cargo test --all-features` + `cargo clippy --all-features` grün; i18n-Key-Parität (de/en) hält; EN-FTL ohne Umlaute. Empirisch (casoon.de, mv-lack, example.com, cloudflare): die Note feuert **nicht** fälschlich — alle Testseiten haben in diesen strengen Modulen reale Findings, daher korrekt kein Hinweis. Der Hinweis greift, sobald eine Sektion tatsächlich findings-frei ist.

Hinweis: #396 ist ein Epic, dessen 7 Sub-Issues (#397–#403) bereits geschlossen sind — es kann als erledigt geschlossen werden.