### PR TITLE
Scoring-Korrekturen aus den 14.06.-Reports (#455, #456, #457)

### DIFF
--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -388,9 +388,14 @@ impl RiskAssessment {
             return self.summary.clone();
         }
         match self.level {
-            RiskLevel::Critical => format!(
+            // Breadth-driven vs. volume-driven Critical (#457).
+            RiskLevel::Critical if self.legal_flags >= 3 => format!(
                 "Critical risk: {} WCAG Level A violations with legal relevance (BFSG). {} blocking issues on interactive controls.",
                 self.legal_flags, self.blocking_issues
+            ),
+            RiskLevel::Critical => format!(
+                "Critical risk: {} critical violations on interactive controls and content.",
+                self.critical_issues
             ),
             RiskLevel::High => format!(
                 "High risk: {} critical and {} severe issues. Users are actively excluded.",
@@ -1228,13 +1233,14 @@ fn compute_risk_assessment(
     // Risk level — explicit precedence; legal_flags and blocking_issues both
     // raise the floor even when critical_issues is zero (see issue #250).
     //
-    // "Critical" is reserved for *systemic* legal exposure: multiple distinct
-    // WCAG Level A barriers (breadth) or a high volume of critical violations.
-    // A single isolated legal flag with a few critical occurrences is serious
-    // but not critical — it falls through to High. Previously any
-    // `legal_flags > 0 && critical_issues > 0` was Critical, which labelled
-    // almost every audited site as critical legal risk.
-    let level = if (legal_flags >= 3 && critical_issues > 0) || critical_issues >= 5 {
+    // "Critical" is reserved for *systemic* legal exposure: breadth (≥3 distinct
+    // WCAG Level A rules with High/Critical severity) OR volume (≥5 critical
+    // occurrences). The breadth path must NOT also require a critical occurrence
+    // — legal_flags already counts High-severity Level A rules, so gating it on
+    // `critical_issues > 0` made a site with 4 High-severity legal barriers rank
+    // *below* one with a single flag but 5+ critical occurrences (#457). A single
+    // isolated legal flag with a few critical occurrences stays High (#250).
+    let level = if legal_flags >= 3 || critical_issues >= 5 {
         RiskLevel::Critical
     } else if (legal_flags > 0 && critical_issues > 0)
         || critical_issues >= 3
@@ -1273,16 +1279,26 @@ fn compute_risk_assessment(
             } else {
                 "Kritisches Risiko"
             };
-            format!(
-                "{}: {} mit rechtlicher Relevanz (BFSG). {}.",
-                prefix,
-                plural(legal_flags, "WCAG-Level-A-Verstoß", "WCAG-Level-A-Verstöße"),
-                plural(
-                    blocking_issues,
-                    "Blocker bei Bedienelementen",
-                    "Blocker bei Bedienelementen"
+            if legal_flags >= 3 {
+                // Breadth-driven: multiple distinct legally-relevant barriers.
+                format!(
+                    "{}: {} mit rechtlicher Relevanz (BFSG). {}.",
+                    prefix,
+                    plural(legal_flags, "WCAG-Level-A-Verstoß", "WCAG-Level-A-Verstöße"),
+                    plural(
+                        blocking_issues,
+                        "Blocker bei Bedienelementen",
+                        "Blocker bei Bedienelementen"
+                    )
                 )
-            )
+            } else {
+                // Volume-driven: a high number of critical occurrences.
+                format!(
+                    "{}: {} auf Bedienelementen und Inhalten.",
+                    prefix,
+                    plural(critical_issues, "kritischer Verstoß", "kritische Verstöße")
+                )
+            }
         }
         RiskLevel::High => format!(
             "Hohes Risiko: {} und {}. Nutzer werden aktiv ausgeschlossen.",
@@ -1358,7 +1374,11 @@ fn compute_risk_assessment(
     let (threshold, driven_by) = match level {
         RiskLevel::Critical => (
             60u32,
-            if legal_flags > 0 {
+            // Attribute to the condition that actually triggered Critical:
+            // breadth of legal exposure (≥3 distinct Level A rules) vs. a high
+            // volume of critical occurrences. A single flag that rode in on
+            // volume must not be labelled "Legal Compliance" (#457).
+            if legal_flags >= 3 {
                 "Legal Compliance"
             } else {
                 "Accessibility"

--- a/src/audit/pipeline.rs
+++ b/src/audit/pipeline.rs
@@ -304,8 +304,13 @@ pub async fn run_single_audit(
     let (mut report, snapshot) = audit_page(&page, url, config, browser).await?;
 
     if config.check_performance {
+        let content_weight = report
+            .performance
+            .as_ref()
+            .and_then(|p| p.content_weight.clone());
         let (throttled, canonical) =
-            collect_throttled_performance(&page, url, browser, config).await;
+            collect_throttled_performance(&page, url, browser, config, content_weight.as_ref())
+                .await;
         report.throttled_performance = throttled;
         if let Some((vitals, score)) = canonical {
             apply_canonical_perf(&mut report, vitals, score);
@@ -970,6 +975,7 @@ async fn collect_throttled_performance(
     url: &str,
     browser: &BrowserManager,
     _config: &PipelineConfig,
+    content_weight: Option<&crate::performance::ContentWeight>,
 ) -> (
     Vec<crate::audit::report::ThrottledPerfResult>,
     Option<(
@@ -1020,7 +1026,11 @@ async fn collect_throttled_performance(
 
         match crate::performance::extract_web_vitals(page).await {
             Ok(vitals) => {
-                let score = calculate_performance_score(&vitals, None);
+                // Pass the headline content_weight so the size/JS/request caps
+                // apply to throttled profiles too — otherwise a throttled
+                // profile can out-score the headline (and Slow3G out-score
+                // Fast3G) purely because its caps were skipped (#456).
+                let score = calculate_performance_score(&vitals, content_weight);
                 // If LCP could not be measured under throttling (timeout or
                 // navigation pre-completion), the most important navigation
                 // metric is missing — do not let CLS/TBT alone push the score

--- a/src/performance/scoring.rs
+++ b/src/performance/scoring.rs
@@ -165,7 +165,6 @@ pub fn calculate_performance_score(
     let mut size_cap = 100u32;
     let mut js_cap = 100u32;
     let mut req_cap = 100u32;
-    let mut dom_cap = 100u32;
 
     if let Some(cw) = content_weight {
         // Page Size (Total Bytes): > 2MB starts linear penalty (5 points per MB, max 30)
@@ -215,28 +214,29 @@ pub fn calculate_performance_score(
         }
     }
 
-    // DOM Nodes (WebVitals): > 1000 nodes starts linear penalty (2 points per 100 nodes, max 15)
+    // DOM Nodes (WebVitals): a degressive penalty, NOT a hard cap. A base
+    // linear penalty (2 points per 100 nodes from 1000, up to 15) covers
+    // moderate bloat; a logarithmic surcharge above 6000 nodes keeps very large
+    // DOMs costing more, bounded at 35 points total. Modelling DOM size as a
+    // hard cap (→ 59) flattened pages with perfect Core Web Vitals to a fixed
+    // score below a janky-CLS page, inverting the ranking (#455).
     if let Some(nodes) = vitals.dom_nodes {
         if nodes > 1000 {
-            let penalty = ((((nodes - 1000) as f64 / 100.0).round() * 2.0).min(15.0)) as u32;
+            let base = (((nodes - 1000) as f64 / 100.0).round() * 2.0).min(15.0);
+            let excess = nodes.saturating_sub(6000) as f64;
+            let surcharge = if excess > 0.0 {
+                (excess / 1000.0).ln_1p() * 4.0
+            } else {
+                0.0
+            };
+            let penalty = (base + surcharge).round().min(35.0) as u32;
             dom_penalty = Some(penalty);
             overall = overall.saturating_sub(penalty);
-        }
-
-        // DOM nodes caps: only genuinely excessive DOMs cap the score.
-        // Moderate DOM bloat is already handled by the linear penalty above
-        // (up to 15 points from 1000 nodes); a hard cap at low thresholds made
-        // ordinary content sites (3000–5000 nodes are common today) all cluster
-        // at exactly 59. Caps now bite only at extreme node counts.
-        if nodes > 10000 {
-            dom_cap = 59;
-        } else if nodes > 6000 {
-            dom_cap = 74;
         }
     }
 
     // Apply caps
-    let min_cap = size_cap.min(js_cap).min(req_cap).min(dom_cap);
+    let min_cap = size_cap.min(js_cap).min(req_cap);
     if overall > min_cap {
         overall = min_cap;
         is_capped = Some(true);
@@ -515,9 +515,9 @@ mod tests {
     }
 
     #[test]
-    fn test_dom_nodes_penalty_without_cap_for_common_sizes() {
-        // 2500 nodes is common for modern content sites: the linear penalty
-        // applies but no hard cap (caps now bite only above 6000/10000).
+    fn test_dom_nodes_penalty_for_common_sizes() {
+        // 2500 nodes is common for modern content sites: the base linear penalty
+        // applies (no surcharge below 6000 nodes), and DOM size never caps.
         let vitals = WebVitals {
             lcp: Some(VitalMetric::new(1000.0, 2500.0, 4000.0)),
             fcp: Some(VitalMetric::new(800.0, 1800.0, 3000.0)),
@@ -529,12 +529,12 @@ mod tests {
 
         let s = calculate_performance_score(&vitals, None);
         assert_eq!(s.dom_penalty, Some(15)); // (2500-1000)/100 * 2 = 30 -> max 15
-        assert_eq!(s.is_capped, None); // not capped at this size anymore
-        assert_eq!(s.overall, 85); // 100 - 15 penalty, no cap
+        assert_eq!(s.is_capped, None);
+        assert_eq!(s.overall, 85); // 100 - 15 penalty
     }
 
     #[test]
-    fn test_dom_nodes_caps_only_when_excessive() {
+    fn test_dom_penalty_is_degressive_not_a_hard_cap() {
         let base = WebVitals {
             lcp: Some(VitalMetric::new(1000.0, 2500.0, 4000.0)),
             fcp: Some(VitalMetric::new(800.0, 1800.0, 3000.0)),
@@ -542,27 +542,50 @@ mod tests {
             tbt: Some(VitalMetric::new(50.0, 200.0, 600.0)),
             ..Default::default()
         };
-
-        // > 6000 nodes -> cap 74
-        let s = calculate_performance_score(
-            &WebVitals {
-                dom_nodes: Some(7000),
-                ..base.clone()
-            },
-            None,
+        let score_at = |nodes| {
+            calculate_performance_score(
+                &WebVitals {
+                    dom_nodes: Some(nodes),
+                    ..base.clone()
+                },
+                None,
+            )
+            .overall
+        };
+        // Monotonic: more nodes -> lower score, but never a fixed hard cap.
+        assert!(score_at(7000) > score_at(20000));
+        assert!(score_at(20000) >= score_at(250000));
+        // Bounded: even a 250k-node DOM with perfect vitals stays well above the
+        // old hard floor of 59 (penalty capped at 35 points) (#455).
+        assert!(
+            score_at(250000) >= 65,
+            "huge DOM scored {}",
+            score_at(250000)
         );
-        assert_eq!(s.overall, 74);
-        assert_eq!(s.is_capped, Some(true));
+    }
 
-        // > 10000 nodes -> cap 59
-        let s = calculate_performance_score(
-            &WebVitals {
-                dom_nodes: Some(11000),
-                ..base
-            },
-            None,
-        );
-        assert_eq!(s.overall, 59);
-        assert_eq!(s.is_capped, Some(true));
+    #[test]
+    fn test_perfect_vitals_huge_dom_outranks_janky_cls() {
+        // Regression for #455: perfect Core Web Vitals + a huge DOM must not
+        // score below a page with poor CLS.
+        let perfect_big_dom = WebVitals {
+            lcp: Some(VitalMetric::new(1200.0, 2500.0, 4000.0)),
+            fcp: Some(VitalMetric::new(1200.0, 1800.0, 3000.0)),
+            cls: Some(VitalMetric::new(0.0, 0.1, 0.25)),
+            tbt: Some(VitalMetric::new(0.0, 200.0, 600.0)),
+            dom_nodes: Some(20000),
+            ..Default::default()
+        };
+        let janky_cls = WebVitals {
+            lcp: Some(VitalMetric::new(900.0, 2500.0, 4000.0)),
+            fcp: Some(VitalMetric::new(800.0, 1800.0, 3000.0)),
+            cls: Some(VitalMetric::new(0.616, 0.1, 0.25)),
+            tbt: Some(VitalMetric::new(0.0, 200.0, 600.0)),
+            dom_nodes: Some(2000),
+            ..Default::default()
+        };
+        let a = calculate_performance_score(&perfect_big_dom, None).overall;
+        let b = calculate_performance_score(&janky_cls, None).overall;
+        assert!(a > b, "perfect+bigDOM {a} must outrank jankyCLS {b}");
     }
 }

--- a/tests/report_consistency_tests.rs
+++ b/tests/report_consistency_tests.rs
@@ -739,6 +739,46 @@ fn normalized_report_survives_cache_round_trip() {
 }
 
 #[test]
+fn test_risk_breadth_critical_without_critical_occurrences() {
+    // Regression for #457: 4 distinct WCAG Level A rules, all High severity (no
+    // Critical occurrences). Breadth of legal exposure must reach Critical and
+    // be attributed to Legal Compliance — a site like this previously ranked
+    // *below* one with a single flag but volume-triggered Critical.
+    let mut results = WcagResults::new();
+    for (rule, name) in [
+        ("1.1.1", "Non-text Content"),
+        ("2.4.4", "Link Purpose"),
+        ("2.4.6", "Headings"),
+        ("3.3.2", "Labels"),
+    ] {
+        results.add_violation(Violation::new(
+            rule,
+            name,
+            WcagLevel::A,
+            Severity::High,
+            "issue",
+            "node",
+        ));
+    }
+    let report = AuditReport::new(
+        "https://example.com".to_string(),
+        WcagLevel::AA,
+        results,
+        100,
+    );
+    let normalized = normalize(&report);
+
+    assert_eq!(normalized.risk.critical_issues, 0);
+    assert_eq!(normalized.risk.legal_flags, 4);
+    assert_eq!(
+        normalized.risk.level,
+        auditmysite::audit::normalized::RiskLevel::Critical,
+        "4 distinct Level-A High rules = systemic legal exposure → Critical"
+    );
+    assert_eq!(normalized.risk.driven_by, "Legal Compliance");
+}
+
+#[test]
 fn test_risk_low_without_violations() {
     let report = AuditReport::new(
         "https://example.com".to_string(),


### PR DESCRIPTION
Drei eng verwandte Scoring-Befunde aus den Single-Reports vom 14.06. — zwei davon refinen meine eigenen Änderungen der letzten Runde.

## #455 — DOM-Cap → degressiver Penalty
Der harte DOM-Cap (>10000 → 59) flachte Seiten mit **perfekten** Core Web Vitals auf einen Fixwert ab — unter eine Seite mit schlechtem CLS (casoon 59 < wai-w3 60, Ranking-Inversion). DOM-Größe ist jetzt ein **degressiver Penalty**: Basis-Linear (bis 15) + log-Zuschlag ab 6000 Knoten, gedeckelt bei 35 Punkten — kein harter Cap mehr.
**Empirisch:** casoon (21054 Knoten, perfekte Vitals) → **74** statt 59-capped; rankt jetzt über janky-CLS-Seiten.

## #456 — content_weight-Caps für Throttled-Profile
Throttled-Profile wurden mit `content_weight = None` bewertet → Size/JS/Request-Caps griffen dort nie, beim Headline-Score aber schon. Folge: `throttled_avg > headline` und Slow3G > Fast3G. Die Headline-`content_weight` wird jetzt durchgereicht.
**Empirisch:** gov-uk Slow3G **78** < Fast3G **82** (Inversion behoben); throttled_avg ≈ headline.

## #457 — Risk: Breadth entkoppeln + ehrliches driven_by
1. Der Breadth-Pfad verlangte `legal_flags >= 3 && critical_issues > 0`. Da `legal_flags` High/Critical-Level-A-Regeln zählt, fiel eine Seite mit 4 High-Severity-Barrieren (critical_issues=0) auf High zurück, während eine mit 1 Flag + 5 Critical-Occurrences Critical erreichte → **mehr Exposition = niedrigeres Risk.** Breadth triggert jetzt auf `legal_flags >= 3` allein.
2. `driven_by`/Summary etikettierten volumen-getriggertes Critical als „Legal Compliance" und rahmten den *einen* Flag als Ursache. Beide spiegeln jetzt den echten Auslöser: Breadth → Legal Compliance, Volumen → Accessibility.
**Empirisch:** gov-uk (1 Flag, 6 Critical-Occ.) → Critical, `driven_by: Accessibility`, Summary „6 kritische Verstöße auf Bedienelementen und Inhalten."

## Validierung
`cargo test --all-features` + `cargo clippy --all-features` grün. Neue Regressionstests: `test_dom_penalty_is_degressive_not_a_hard_cap`, `test_perfect_vitals_huge_dom_outranks_janky_cls`, `test_risk_breadth_critical_without_critical_occurrences`. Alle drei zusätzlich live an casoon.de/gov.uk verifiziert.