### PR TITLE
fix(report): occurrence counting in diagnosis, WCAG-scoped root causes

### DIFF
--- a/src/a11y_journey/link_inventory.rs
+++ b/src/a11y_journey/link_inventory.rs
@@ -197,8 +197,7 @@ fn check_heading_outline(tree: &AXTree) -> Vec<InteractiveFinding> {
                 identify the main structure of the page without an H1."
                 .to_string(),
             fix_suggestion: Some(
-                "Use exactly one H1 heading per page that describes the main content."
-                    .to_string(),
+                "Use exactly one H1 heading per page that describes the main content.".to_string(),
             ),
         });
     }

--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -1279,7 +1279,11 @@ fn compute_risk_assessment(
                 format!(
                     "{}: {} with legal relevance (BFSG). {}.",
                     prefix,
-                    plural(legal_flags, "WCAG Level A violation", "WCAG Level A violations"),
+                    plural(
+                        legal_flags,
+                        "WCAG Level A violation",
+                        "WCAG Level A violations"
+                    ),
                     plural(
                         blocking_issues,
                         "blocker on interactive elements",
@@ -1298,17 +1302,17 @@ fn compute_risk_assessment(
         RiskLevel::High => format!(
             "High risk: {} and {}. Users are actively excluded.",
             plural(critical_issues, "critical issue", "critical issues"),
-            plural(
-                high_issues,
-                "serious issue",
-                "serious issues"
-            )
+            plural(high_issues, "serious issue", "serious issues")
         ),
         RiskLevel::Medium => {
             if legal_flags > 0 {
                 format!(
                     "Medium risk: {} with legal relevance (BFSG){}.",
-                    plural(legal_flags, "WCAG Level A violation", "WCAG Level A violations"),
+                    plural(
+                        legal_flags,
+                        "WCAG Level A violation",
+                        "WCAG Level A violations"
+                    ),
                     if blocking_issues > 0 {
                         format!(
                             ", {} on interactive elements",
@@ -1361,8 +1365,7 @@ fn compute_risk_assessment(
                     plural(notable, "notable finding", "notable findings")
                 )
             } else {
-                "Low risk: No critical violations — improvement potential exists."
-                    .to_string()
+                "Low risk: No critical violations — improvement potential exists.".to_string()
             }
         }
     };

--- a/src/audit/summary.rs
+++ b/src/audit/summary.rs
@@ -232,23 +232,48 @@ fn detect_dominant_issue(
     findings: &[NormalizedFinding],
     urgent_occurrences: usize,
 ) -> Option<DominantIssue> {
-    if urgent_occurrences == 0 {
-        return None;
-    }
-
-    // Accumulate group count and occurrence total per rule_id.
-    let mut rule_counts: HashMap<&str, (&NormalizedFinding, usize, usize)> = HashMap::new();
-    for f in findings {
-        if matches!(f.severity, Severity::Critical | Severity::High) {
-            let entry = rule_counts.entry(&f.rule_id).or_insert((f, 0, 0));
-            entry.1 += 1; // group count
-            entry.2 += f.occurrence_count; // occurrence total
+    // Phase 1: dominance among critical/high findings (threshold ≥ 45 %).
+    if urgent_occurrences > 0 {
+        let mut rule_counts: HashMap<&str, (&NormalizedFinding, usize, usize)> = HashMap::new();
+        for f in findings {
+            if matches!(f.severity, Severity::Critical | Severity::High) {
+                let entry = rule_counts.entry(&f.rule_id).or_insert((f, 0, 0));
+                entry.1 += 1; // group count
+                entry.2 += f.occurrence_count; // occurrence total
+            }
+        }
+        let result = rule_counts
+            .into_values()
+            .filter(|(_, _, occ_total)| (*occ_total as f32 / urgent_occurrences as f32) >= 0.45)
+            .max_by_key(|(_, _, occ_total)| *occ_total)
+            .map(|(f, count, occurrence_total)| DominantIssue {
+                rule_id: f.rule_id.clone(),
+                title: f.title.clone(),
+                severity: f.severity,
+                count,
+                occurrence_total,
+                share_pct: occurrence_total as f32 / urgent_occurrences as f32 * 100.0,
+            });
+        if result.is_some() {
+            return result;
         }
     }
 
+    // Phase 2: when no critical/high dominance is found, check all findings.
+    // Higher threshold (≥ 60 %) because medium/low findings have less individual weight.
+    let all_occurrences: usize = findings.iter().map(|f| f.occurrence_count).sum();
+    if all_occurrences == 0 {
+        return None;
+    }
+    let mut rule_counts: HashMap<&str, (&NormalizedFinding, usize, usize)> = HashMap::new();
+    for f in findings {
+        let entry = rule_counts.entry(&f.rule_id).or_insert((f, 0, 0));
+        entry.1 += 1;
+        entry.2 += f.occurrence_count;
+    }
     rule_counts
         .into_values()
-        .filter(|(_, _, occ_total)| (*occ_total as f32 / urgent_occurrences as f32) >= 0.45)
+        .filter(|(_, _, occ_total)| (*occ_total as f32 / all_occurrences as f32) >= 0.60)
         .max_by_key(|(_, _, occ_total)| *occ_total)
         .map(|(f, count, occurrence_total)| DominantIssue {
             rule_id: f.rule_id.clone(),
@@ -256,7 +281,7 @@ fn detect_dominant_issue(
             severity: f.severity,
             count,
             occurrence_total,
-            share_pct: occurrence_total as f32 / urgent_occurrences as f32 * 100.0,
+            share_pct: occurrence_total as f32 / all_occurrences as f32 * 100.0,
         })
 }
 

--- a/src/dark_mode/mod.rs
+++ b/src/dark_mode/mod.rs
@@ -301,11 +301,10 @@ fn build_issues(
     if !info.has_dark_media_query && info.has_class_based_dark_mode {
         issues.push(DarkModeIssue {
             kind: DarkModeIssueKind::IncompleteImplementation,
-            description:
-                "Class-based dark mode detected (html.dark / [data-theme=\"dark\"]). \
+            description: "Class-based dark mode detected (html.dark / [data-theme=\"dark\"]). \
                           Contrast checking in dark mode via CDP emulation is not possible — \
                           only @media (prefers-color-scheme: dark) can be tested automatically."
-                    .to_string(),
+                .to_string(),
             severity: "low".to_string(),
         });
     }

--- a/src/output/builder/single/actions_block.rs
+++ b/src/output/builder/single/actions_block.rs
@@ -42,6 +42,17 @@ pub(super) fn build_actions_block(
         }
     }
 
+    // Cross-bucket dedup: derive_action_plan deduplicates within effort buckets,
+    // but two findings with slightly different raw recommendations can produce the
+    // same humanized action text and land in different priority buckets here.
+    {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        blockers.retain(|i| seen.insert(i.action.clone()));
+        high_prio.retain(|i| seen.insert(i.action.clone()));
+        medium_prio.retain(|i| seen.insert(i.action.clone()));
+        low_prio.retain(|i| seen.insert(i.action.clone()));
+    }
+
     // Within each bucket sort by execution_priority descending
     let sort_bucket = |mut v: Vec<ActionItem>| -> Vec<ActionItem> {
         v.sort_by_key(|i| std::cmp::Reverse(i.execution_priority));

--- a/src/output/builder/single/diagnosis.rs
+++ b/src/output/builder/single/diagnosis.rs
@@ -318,7 +318,7 @@ pub(super) fn build_diagnosis_block(
         let entry = dim_map
             .entry(dim)
             .or_insert((0, crate::wcag::Severity::Low));
-        entry.0 += 1;
+        entry.0 += f.occurrence_count;
         if f.severity > entry.1 {
             entry.1 = f.severity;
         }

--- a/src/output/explanations.rs
+++ b/src/output/explanations.rs
@@ -232,6 +232,67 @@ static EXPLANATIONS: &[(&str, RuleExplanation)] = &[
             example_decorative: None,
         },
     ),
+    // Rule-specific override for presentation-semantic-children violations.
+    // The WCAG 1.3.1 fallback is too generic (tables/lists/forms) for this case —
+    // the actual issue is an ARIA role conflict in navigation markup.
+    (
+        "a11y.presentation_semantic_children.invalid",
+        RuleExplanation {
+            customer_title: "ARIA-Rollen-Konflikt in Navigation",
+            customer_title_en: "ARIA role conflict in navigation",
+            customer_description:
+                "Ein Element ist mit role=\"none\" als semantisch leer markiert, \
+                 enthält aber Kindelemente mit eigenen ARIA-Rollen. Das verwirrt \
+                 Screenreader: Der Container hat keine Semantik, aber die enthaltenen \
+                 Elemente referenzieren Rollentypen, die einen bestimmten Container \
+                 voraussetzen.",
+            customer_description_en:
+                "An element is marked as semantically empty with role=\"none\", but \
+                 contains child elements with their own ARIA roles. This confuses screen \
+                 readers: the container has no semantics, but the contained elements \
+                 reference role types that require a specific parent container.",
+            user_impact:
+                "Screenreader können Navigationsmenüs nicht korrekt interpretieren. \
+                 Tastaturnutzer erhalten möglicherweise falsche oder fehlende \
+                 Navigationshinweise.",
+            user_impact_en:
+                "Screen readers cannot correctly interpret navigation menus. Keyboard \
+                 users may receive incorrect or missing navigation cues.",
+            typical_cause:
+                "Verwendung von ARIA-Mustern aus Desktop-Anwendungen (z. B. \
+                 role=\"menuitem\") für Website-Navigation. role=\"none\" auf \
+                 List-Elementen, die ARIA-Kinder mit Rollenanforderungen enthalten.",
+            typical_cause_en:
+                "Using ARIA patterns from desktop applications (e.g. role=\"menuitem\") \
+                 for website navigation. role=\"none\" on list items that contain ARIA \
+                 children with role requirements.",
+            recommendation:
+                "Website-Navigation ohne ARIA-Menubar-Muster aufbauen: \
+                 <nav><ul><li><a> reicht für Screenreader aus. role=\"menuitem\" und \
+                 role=\"menubar\" sind für Desktop-App-Menüs reserviert, nicht für \
+                 Seitennavigation. role=\"none\" nur auf Elementen verwenden, die \
+                 wirklich keine Kinder mit Eigenrollen haben.",
+            recommendation_en:
+                "Build website navigation without the ARIA Menubar pattern: \
+                 <nav><ul><li><a> is sufficient for screen readers. role=\"menuitem\" \
+                 and role=\"menubar\" are reserved for desktop application menus, not \
+                 website navigation. Only use role=\"none\" on elements that truly have \
+                 no children with their own roles.",
+            technical_note:
+                "ARIA APG: Navigation-Menubar ist für App-ähnliche Menüs mit \
+                 Pfeilnavigation. Website-Navigation verwendet <nav> + natürliche \
+                 Listenstruktur. role=\"none\" hebt nicht die Rollen von Nachfahren auf.",
+            technical_note_en:
+                "ARIA APG: Navigation Menubar is for app-like menus with arrow key \
+                 navigation. Website navigation uses <nav> + natural list structure. \
+                 role=\"none\" does not remove the roles of descendant elements.",
+            responsible_role: Role::Development,
+            effort_estimate: Effort::Quick,
+            example_bad: Some("<li role=\"none\"><a href=\"/home\" role=\"menuitem\">Home</a></li>"),
+            example_good: Some("<li><a href=\"/home\">Home</a></li>"),
+            example_decorative: None,
+        },
+    ),
     (
         "1.3.5",
         RuleExplanation {

--- a/src/output/json/detail.rs
+++ b/src/output/json/detail.rs
@@ -99,7 +99,13 @@ pub(super) fn build_detail_cached(
 
 pub(super) fn build_detail(ctx: &AuditContext<'_>, detail_ctx: DetailContext) -> PageDetail {
     // JSON is canonical English (#406) — always build the view model with "en".
-    let vm = build_view_model(ctx, &ReportConfig { locale: "en".to_string(), ..ReportConfig::default() });
+    let vm = build_view_model(
+        ctx,
+        &ReportConfig {
+            locale: "en".to_string(),
+            ..ReportConfig::default()
+        },
+    );
     let normalized: &NormalizedReport = &ctx.normalized;
     let mut errors = detail_ctx.collection_errors;
 

--- a/src/output/pdf/diagnosis.rs
+++ b/src/output/pdf/diagnosis.rs
@@ -55,7 +55,7 @@ pub(super) fn render_diagnosis_section(
     // Category breakdown table
     if !diagnosis.category_breakdown.is_empty() {
         let col_dim = i18n.t("diagnosis-col-category");
-        let col_count = i18n.t("diagnosis-col-findings");
+        let col_count = i18n.t("diagnosis-col-occurrences");
         let col_sev = i18n.t("diagnosis-col-worst-severity");
         let table_title = i18n.t("diagnosis-table-categories");
         let mut table = AuditTable::new(vec![

--- a/src/output/pdf/single_report.rs
+++ b/src/output/pdf/single_report.rs
@@ -1075,12 +1075,13 @@ pub(super) fn render_root_cause_analysis(
             .with_level(2),
     );
 
-    // Let's filter the accessibility findings from all_findings, sorted by occurrence count desc
+    // Only WCAG/Mandatory findings — scope matches the header "N Accessibility-Befunde" count.
+    // SEO findings (Optimization tier) appear in their own section below.
     let mut findings: Vec<&FindingGroup> = vm
         .findings
         .all_findings
         .iter()
-        .filter(|f| f.occurrence_count > 0)
+        .filter(|f| f.occurrence_count > 0 && f.criticality_tier == CriticalityTier::Mandatory)
         .collect();
     findings.sort_by_key(|f| std::cmp::Reverse(f.occurrence_count));
 
@@ -1094,11 +1095,11 @@ pub(super) fn render_root_cause_analysis(
         return builder;
     }
 
-    // Render list of component errors (assigning letters A, B, C, etc.)
+    // Render root causes (assigning letters A, B, C, etc.)
     let mut list = List::new().with_title(if en {
         "Systemic Root Causes"
     } else {
-        "Erkannte Kernursachen (Templates)"
+        "Erkannte Kernursachen"
     });
     let mut table_rows = Vec::new();
     let total_occurrences: usize = findings.iter().map(|f| f.occurrence_count).sum();
@@ -1107,11 +1108,7 @@ pub(super) fn render_root_cause_analysis(
         let letter = (b'A' + idx as u8) as char;
         let item_title = format!(
             "{} {}: {} Vorkommen — {}",
-            if en {
-                "Component Issue"
-            } else {
-                "Komponentenfehler"
-            },
+            if en { "Root Cause" } else { "Ursache" },
             letter,
             finding.occurrence_count,
             finding.title


### PR DESCRIPTION
Report-quality WIP, separate from the #479–#488 batch (PR #489).

- **Diagnosis category breakdown** now counts `occurrence_count` instead of finding groups; PDF column relabelled *Findings → Occurrences* (`diagnosis-col-occurrences`, de+en) to match.
- **Root-cause analysis** section filtered to `CriticalityTier::Mandatory` (WCAG), so it matches the "N Accessibility findings" header scope — SEO has its own section. Neutral wording (*Root cause / Ursache*) instead of *Component issue (Templates)*.
- **Actions block**: cross-bucket dedup of identical humanized action texts that `derive_action_plan` can place in different priority buckets.
- **Dominant-issue detection**: two-phase — critical/high dominance ≥45 %, else all findings ≥60 % — so medium/low-only pages still surface a driver.
- **Rule explanation** added for `a11y.presentation_semantic_children.invalid` (ARIA role conflict in navigation), more specific than the generic 1.3.1 fallback.

Verification: `cargo test --lib --all-features` 967 passed; `cargo check --all-features` clean.