### PR TITLE
fix(ci): repair red pipeline (no-pdf build, clippy, schema/i18n drift)

### DIFF
--- a/docs/json-batch-report.schema.json
+++ b/docs/json-batch-report.schema.json
@@ -72,6 +72,7 @@
         "url_count": { "type": "integer", "minimum": 0 },
         "accessibility_score": { "type": "integer", "minimum": 0, "maximum": 100 },
         "overall_score": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 },
         "grade": { "type": "string" },
         "certificate": { "type": "string" },
         "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },

--- a/docs/json-report.schema.json
+++ b/docs/json-report.schema.json
@@ -52,6 +52,7 @@
         "url_count": { "type": "integer", "minimum": 0 },
         "accessibility_score": { "type": "integer", "minimum": 0, "maximum": 100 },
         "overall_score": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 },
         "grade": { "type": "string" },
         "certificate": { "type": "string" },
         "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
@@ -220,7 +221,9 @@
         "content_visibility": { "type": ["object", "null"] },
         "tech_stack": { "type": ["object", "null"] },
         "patterns": { "type": ["object", "null"] },
-        "best_practices": { "type": ["object", "null"] }
+        "best_practices": { "type": ["object", "null"] },
+        "dual_viewport": { "type": ["object", "null"] },
+        "search_experience": { "type": ["object", "null"] }
       }
     },
     "principleCoverage": {

--- a/src/dark_mode/mod.rs
+++ b/src/dark_mode/mod.rs
@@ -276,6 +276,7 @@ pub async fn analyze_dark_mode(page: &Page, wcag_level: WcagLevel) -> Result<Dar
 
 // ─── Issue generation ─────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 fn build_issues(
     info: &StaticDarkModeInfo,
     dark_contrast_count: u32,

--- a/src/output/builder/batch.rs
+++ b/src/output/builder/batch.rs
@@ -50,7 +50,7 @@ pub fn build_batch_presentation_with_normalized(
         normalized_reports.len(),
         "batch presentation requires one normalized report per raw report"
     );
-    let collected = collect_batch_finding_groups(&normalized_reports, i18n);
+    let collected = collect_batch_finding_groups(normalized_reports, i18n);
     // Deduplicate findings with the same title across rule sources; prefer
     // non-"unknown." rule_ids, merge occurrence counts.
     let mut seen_titles: std::collections::HashMap<String, usize> =

--- a/src/output/builder/single/mod.rs
+++ b/src/output/builder/single/mod.rs
@@ -1053,6 +1053,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pdf")]
     fn test_active_modules_have_json_detail_and_pdf_registry_coverage() {
         use crate::output::json::UnifiedReport;
         use crate::output::module::{active_modules, active_report_modules};

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,7 @@ pub mod builder;
 mod cli;
 pub mod explanations;
 mod json;
+#[cfg(feature = "pdf")]
 mod localized;
 pub mod module;
 #[cfg(feature = "pdf")]

--- a/src/output/module.rs
+++ b/src/output/module.rs
@@ -17,6 +17,7 @@ use crate::audit::{AuditReport, PerformanceResults};
 use crate::best_practices::BestPracticesAnalysis;
 use crate::content_visibility::ContentVisibilityAnalysis;
 use crate::dark_mode::DarkModeAnalysis;
+#[cfg(feature = "pdf")]
 use crate::i18n::I18n;
 use crate::journey::JourneyAnalysis;
 use crate::mobile::MobileFriendliness;
@@ -27,6 +28,7 @@ use crate::source_quality::SourceQualityAnalysis;
 use crate::tech_stack::TechStackAnalysis;
 use crate::ux::UxAnalysis;
 
+#[cfg(feature = "pdf")]
 pub type PdfComponents = Vec<Box<dyn renderreport::components::Component>>;
 
 /// Interface contract for optional audit modules.
@@ -38,9 +40,11 @@ pub trait ReportModule {
     fn to_json(&self) -> Value;
 
     /// Render a structural PDF hook for this module.
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents;
 }
 
+#[cfg(feature = "pdf")]
 fn pdf_marker(module_key: &str, i18n: &I18n) -> PdfComponents {
     vec![Box::new(renderreport::components::text::TextBlock::new(
         format!("pdf-module:{module_key}:{}", i18n.locale()),
@@ -65,6 +69,7 @@ impl ReportModule for PerformanceResults {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -77,6 +82,7 @@ impl ReportModule for SeoAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -89,6 +95,7 @@ impl ReportModule for SecurityAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -101,6 +108,7 @@ impl ReportModule for MobileFriendliness {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -113,6 +121,7 @@ impl ReportModule for UxAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -125,6 +134,7 @@ impl ReportModule for JourneyAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -137,6 +147,7 @@ impl ReportModule for DarkModeAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -149,6 +160,7 @@ impl ReportModule for SourceQualityAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -161,6 +173,7 @@ impl ReportModule for AiVisibilityAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -173,6 +186,7 @@ impl ReportModule for ContentVisibilityAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -185,6 +199,7 @@ impl ReportModule for BestPracticesAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -197,6 +212,7 @@ impl ReportModule for TechStackAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -209,6 +225,7 @@ impl ReportModule for PatternAnalysis {
     fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
+    #[cfg(feature = "pdf")]
     fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
         pdf_marker(self.module_key(), i18n)
     }
@@ -270,6 +287,7 @@ pub fn active_modules(report: &AuditReport) -> Vec<(&'static str, Value)> {
 
 /// Returns all active modules as trait objects so JSON/PDF coverage tests use
 /// the same compile-time `ReportModule` contract.
+#[cfg(feature = "pdf")]
 pub fn active_report_modules(report: &AuditReport) -> Vec<&dyn ReportModule> {
     let mut out: Vec<&dyn ReportModule> = Vec::new();
 

--- a/src/output/pdf/single_report.rs
+++ b/src/output/pdf/single_report.rs
@@ -1036,13 +1036,11 @@ fn render_active_module_section(
                 return (render_tech_stack(builder, ts, is_first, i18n), true);
             }
         }
-        "patterns" => {
-            if !vm.positive_signals.is_empty() {
-                return (
-                    render_positive_signals_section(builder, &vm.positive_signals, is_first, i18n),
-                    true,
-                );
-            }
+        "patterns" if !vm.positive_signals.is_empty() => {
+            return (
+                render_positive_signals_section(builder, &vm.positive_signals, is_first, i18n),
+                true,
+            );
         }
         _ => {}
     }

--- a/tests/output_format_tests.rs
+++ b/tests/output_format_tests.rs
@@ -142,11 +142,12 @@ fn test_json_report_exposes_confidence_and_capabilities() {
         .as_array()
         .expect("capabilities must be an array");
 
+    // JSON is canonical English (#406).
     assert!(confidence
         .iter()
-        .any(|entry| entry["signal"] == "Audit-Vertrauen"));
+        .any(|entry| entry["signal"] == "Audit confidence"));
     assert!(capabilities.iter().any(|entry| {
-        entry["signal"] == "WCAG-Regeln & Vorkommen"
+        entry["signal"] == "WCAG rules & occurrences"
             && entry["surfaces"]
                 .as_array()
                 .is_some_and(|surfaces| surfaces.iter().any(|s| s == "PDF"))


### PR DESCRIPTION
CI has been red since mid-June. None of this is caused by the recent issue/report PRs — it's pre-existing breakage that the gates surface.

## Build without PDF (`cargo build --no-default-features`)
`src/output/module.rs` referenced `renderreport` (a `pdf`-only dep) ungated. Gated all renderreport-dependent items behind `feature = "pdf"`: `PdfComponents`, the `render_pdf` trait method + 14 impls, `pdf_marker`, `active_report_modules`, the `I18n` import. Also gated the `output::localized` module and the PDF-coverage test (`test_active_modules_have_json_detail_and_pdf_registry_coverage`).

## Clippy (`-D warnings`, both feature sets)
- `batch.rs`: dropped a double reference on the `collect_batch_finding_groups` argument.
- `dark_mode::build_issues`: `#[allow(clippy::too_many_arguments)]` (internal helper, 8 params).
- `single_report.rs`: collapsed the `"patterns"` arm into a match guard.

## Test drift from the #406 JSON-canonical-English migration
- `output_format_tests`: assert English labels (`"Audit confidence"`, `"WCAG rules & occurrences"`) instead of the old German ones.
- JSON schemas: allow `summary.score` and the module-detail keys `dual_viewport` / `search_experience` (single + batch) — these are legitimate output fields that were missing from the schema.

## Verification (locally, mirroring CI)
- `cargo build --no-default-features` ✓
- `cargo clippy --no-default-features -- -D warnings` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --no-default-features` ✓ (all suites)
- `cargo test --features pdf` ✓ (incl. output_format_tests 8/8)
- `cargo test --features pdf_test` PDF smoke ✓ (24/24)