### PR TITLE
feat(commerce): schema-driven shop completeness module (slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ src/
 ├── screen_reader/       # Screen-reader reading-order primitives
 ├── ai_visibility/       # AI/LLM discoverability analysis
 ├── content_visibility/  # Cross-module signal aggregation (SEO+AI+Quality)
+├── commerce/            # Shop schema-completeness (Product/Offer JSON-LD: shipping, returns, reviews, availability) — derive-only, shop-gated
 ├── source_quality/      # Source quality signals (headers, schema, HTTPS)
 ├── tech_stack/          # CMS/framework detection from in-page signals
 ├── patterns/            # UI pattern detection (nav, accordion, modal, …)
@@ -232,7 +233,7 @@ Whenever a new module is added, renamed, or removed, update the Module Structure
 - 2 output formats (json, pdf); table for quick terminal checks
 - Batch processing with configurable concurrency
 - Pattern Detection: MainNavigation, SkipLink, Accordion, Dialog, DisclosureMenu, TabList, Form
-- Modules: Performance, SEO, Security, Mobile, Dark Mode, UX, Journey, AI Visibility, Content Visibility, Source Quality, Tech Stack, Best Practices, Accessibility Journey Layer
+- Modules: Performance, SEO, Security, Mobile, Dark Mode, UX, Journey, AI Visibility, Content Visibility, Source Quality, Tech Stack, Best Practices, Commerce, Accessibility Journey Layer
 - Consent: `--dismiss-consent` Flag; CMP-Cookie-Injection + Banner-Click; `consent_banner` audit_flag im JSON
 - `audit_flags` kinds: `conflicting_signal` (3.1.1 vs. SEO lang), `viewport_gap` (Desktop/Mobile ≥20 Punkte), `consent_banner`, `consent_wall_artifact`, `bypass_blocks_untested` (Skip-Link vorhanden aber funktional kaputt — statischer Check hat PASS, Journey FAIL)
 - JSON: **Unified Report Envelope v2.0** — einheitliches Schema für single + batch (`schema_version`, `report_type`, `summary`, `pages[]`, `pages[i].detail`). Breaking Change ggü. v0.17.

--- a/docs/json-report.schema.json
+++ b/docs/json-report.schema.json
@@ -222,6 +222,7 @@
         "tech_stack": { "type": ["object", "null"] },
         "patterns": { "type": ["object", "null"] },
         "best_practices": { "type": ["object", "null"] },
+        "commerce": { "type": ["object", "null"] },
         "dual_viewport": { "type": ["object", "null"] },
         "search_experience": { "type": ["object", "null"] }
       }

--- a/src/ai_visibility/mod.rs
+++ b/src/ai_visibility/mod.rs
@@ -1254,6 +1254,7 @@ mod tests {
             patterns: None,
             screenshot_status: Default::default(),
             best_practices: None,
+            commerce: None,
             consent_banner_detected: false,
             consent_banner_cmp: None,
             consent_banner_dismissed: false,

--- a/src/audit/artifacts.rs
+++ b/src/audit/artifacts.rs
@@ -307,6 +307,7 @@ pub fn to_audit_report(artifacts: &AuditArtifacts, locale: &str) -> AuditReport 
         patterns: None,
         screenshot_status: Default::default(),
         best_practices: None,
+        commerce: None,
         consent_banner_detected: false,
         consent_banner_cmp: None,
         consent_banner_dismissed: false,

--- a/src/audit/catalog.rs
+++ b/src/audit/catalog.rs
@@ -35,6 +35,7 @@ impl AuditCatalog {
     pub fn standard() -> Self {
         use crate::ai_visibility::AiVisibilityModule;
         use crate::best_practices::BestPracticesModule;
+        use crate::commerce::CommerceModule;
         use crate::content_visibility::ContentVisibilityModule;
         use crate::dark_mode::DarkModeModule;
         use crate::journey::JourneyModule;
@@ -59,6 +60,7 @@ impl AuditCatalog {
             .with_module(Box::new(SourceQualityModule))
             .with_module(Box::new(AiVisibilityModule))
             .with_module(Box::new(ContentVisibilityModule))
+            .with_module(Box::new(CommerceModule))
     }
 
     /// Catalog with no registered modules.
@@ -312,6 +314,7 @@ mod tests {
             "source_quality",
             "ai_visibility",
             "content_visibility",
+            "commerce",
         ]
         .into_iter()
         .collect();

--- a/src/audit/normalized.rs
+++ b/src/audit/normalized.rs
@@ -126,6 +126,7 @@ pub struct AuditContext<'a> {
     pub raw_patterns: Option<&'a crate::patterns::PatternAnalysis>,
     pub raw_throttled_performance: &'a [crate::audit::report::ThrottledPerfResult],
     pub raw_best_practices: Option<&'a crate::best_practices::BestPracticesAnalysis>,
+    pub raw_commerce: Option<&'a crate::commerce::CommerceAnalysis>,
 }
 
 /// Einheitliche Severity-Zähler
@@ -1755,6 +1756,7 @@ pub fn normalize<'a>(report: &'a AuditReport) -> AuditContext<'a> {
         raw_patterns: report.patterns.as_ref(),
         raw_throttled_performance: &report.throttled_performance,
         raw_best_practices: report.best_practices.as_ref(),
+        raw_commerce: report.commerce.as_ref(),
     };
     ctx.normalized.interpretation = Some(Interpretation::from_context(&ctx));
     ctx

--- a/src/audit/pipeline.rs
+++ b/src/audit/pipeline.rs
@@ -272,9 +272,8 @@ impl PipelineConfig {
         // otherwise deserialize *successfully* (unknown keys ignored, new fields
         // defaulted) and silently drop data within the same tool version. Bumped
         // Bumped to 2 for the ExperienceSection move, 3 for AccessibilitySection,
-        // 4 for DiscoverabilitySection (seo/ai_visibility/content_visibility/
-        // source_quality/tech_stack).
-        const CACHE_FMT: u8 = 4;
+        // 4 for DiscoverabilitySection, 5 for the new commerce module field.
+        const CACHE_FMT: u8 = 5;
         format!(
             "v={};fmt={};level={};perf={};seo={};sec={};mobile={};dark={};stack={};consent={};interactive={:?};journey_budget_ms={};lang={}",
             env!("CARGO_PKG_VERSION"),
@@ -1363,6 +1362,7 @@ mod tests {
             "Security",
             "SEO",
             "AI Visibility",
+            "Commerce",
             "Tech Stack",
             "UX",
             "Source Quality",

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -240,6 +240,9 @@ pub struct AuditReport {
     /// Best practices analysis (console errors, vulnerable libraries)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub best_practices: Option<crate::best_practices::BestPracticesAnalysis>,
+    /// Commerce / shop schema-completeness analysis (only on product pages)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commerce: Option<crate::commerce::CommerceAnalysis>,
     /// Whether a consent banner was detected during the audit
     #[serde(default)]
     pub consent_banner_detected: bool,
@@ -345,6 +348,7 @@ impl AuditReport {
             patterns: None,
             screenshot_status: ScreenshotStatus::NotRequested,
             best_practices: None,
+            commerce: None,
             consent_banner_detected: false,
             consent_banner_cmp: None,
             consent_banner_dismissed: false,

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn active_modules_label_default_matches_standard_pipeline() {
         let args = Args::parse_from(["auditmysite", "https://example.com"]);
-        let expected = "Accessibility, Accessibility Journey, Best Practices, Dark Mode, Journey, Mobile, Performance, Security, SEO, AI Visibility, Tech Stack, UX, Source Quality, Content Visibility".to_string();
+        let expected = "Accessibility, Accessibility Journey, Best Practices, Dark Mode, Journey, Mobile, Performance, Security, SEO, AI Visibility, Commerce, Tech Stack, UX, Source Quality, Content Visibility".to_string();
         assert_eq!(active_modules_label(&args), expected);
     }
 

--- a/src/commerce/mod.rs
+++ b/src/commerce/mod.rs
@@ -1,0 +1,457 @@
+//! Commerce / shop audit — schema-driven commercial-completeness signals.
+//!
+//! Derive-only analysis (no CDP): reads the JSON-LD already collected by the SEO
+//! module (`discoverability.seo.structured_data`) and reports whether a product
+//! page exposes the commercial information shoppers (and search/AI) expect —
+//! price, availability/delivery, shipping, returns and reviews — as
+//! machine-readable structured data.
+//!
+//! Self-gating: produces `Some(..)` only on pages that carry `Product`/`Offer`
+//! schema; otherwise `None` (skipped on landing/editorial pages). Absence of a
+//! signal means "not exposed as structured data", which is itself an SEO/AI
+//! visibility gap — it does NOT assert the shop lacks the information on-page.
+//!
+//! Localization (#406): the stored struct is canonical English; findings carry a
+//! `kind` enum and `commerce_finding_text(kind, en)` is the single text source.
+
+pub mod module;
+
+pub use module::CommerceModule;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::seo::StructuredData;
+use crate::taxonomy::Severity;
+
+/// Schema-derived commercial completeness for a product page.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommerceAnalysis {
+    /// Price + currency + validity from `Offer`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<PriceInfo>,
+    /// `Offer.availability` (schema.org URL or token, e.g. `InStock`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub availability: Option<String>,
+    /// Human delivery time from `shippingDetails.deliveryTime`, if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_time: Option<String>,
+    /// Whether `OfferShippingDetails` is present (and free-shipping if derivable).
+    pub shipping: ShippingInfo,
+    /// Whether a `MerchantReturnPolicy` is present (and its window, if given).
+    pub returns: ReturnsInfo,
+    /// `AggregateRating` rating value + review count, if present.
+    pub reviews: ReviewInfo,
+    /// Findings for missing/incomplete commercial structured data.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<CommerceFinding>,
+    /// Share of expected commercial signals exposed (0–100).
+    pub score: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PriceInfo {
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// `priceValidUntil` raw value (ISO date), if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ShippingInfo {
+    /// `OfferShippingDetails` present anywhere on the offer/product.
+    pub has_shipping_details: bool,
+    /// A shipping rate value was found (`shippingRate.value`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shipping_rate: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ReturnsInfo {
+    /// `MerchantReturnPolicy` / `hasMerchantReturnPolicy` present.
+    pub has_return_policy: bool,
+    /// `merchantReturnDays` value, if given.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_days: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ReviewInfo {
+    /// `aggregateRating.ratingValue`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rating_value: Option<String>,
+    /// `aggregateRating.reviewCount` / `ratingCount`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_count: Option<String>,
+}
+
+/// Canonical finding kinds. Text is derived via [`commerce_finding_text`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommerceFindingKind {
+    MissingPrice,
+    MissingAvailability,
+    MissingShippingDetails,
+    MissingReturnPolicy,
+    MissingReviews,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommerceFinding {
+    pub kind: CommerceFindingKind,
+    pub severity: Severity,
+    /// Canonical English message (#406); PDF re-derives via the run locale.
+    pub message: String,
+}
+
+const EXPECTED_SIGNALS: u32 = 5;
+
+/// Analyze commercial completeness from already-collected structured data.
+/// Returns `None` when the page carries no `Product`/`Offer` schema.
+pub fn analyze_commerce(structured_data: &StructuredData) -> Option<CommerceAnalysis> {
+    let product = structured_data
+        .json_ld
+        .iter()
+        .find(|s| schema_is(&s.content, "Product") || schema_is(&s.content, "Offer"))?;
+    let content = &product.content;
+
+    // The Offer may be the root (schema_type Offer) or nested under `offers`
+    // (single object or array). Shipping/returns can live on offer or product.
+    let offer = first_offer(content);
+    let offer_or_product = offer.unwrap_or(content);
+
+    let price = extract_price(offer_or_product, content);
+    let availability = str_field(offer_or_product, "availability").map(normalize_schema_token);
+
+    let shipping = extract_shipping(offer_or_product, content);
+    let delivery_time = extract_delivery_time(offer_or_product, content);
+    let returns = extract_returns(offer_or_product, content);
+    let reviews = extract_reviews(content);
+
+    let mut findings = Vec::new();
+    let mut present = 0u32;
+
+    if price.is_some() {
+        present += 1;
+    } else {
+        findings.push(finding(CommerceFindingKind::MissingPrice, Severity::High));
+    }
+    if availability.is_some() {
+        present += 1;
+    } else {
+        findings.push(finding(
+            CommerceFindingKind::MissingAvailability,
+            Severity::Medium,
+        ));
+    }
+    if shipping.has_shipping_details {
+        present += 1;
+    } else {
+        findings.push(finding(
+            CommerceFindingKind::MissingShippingDetails,
+            Severity::Medium,
+        ));
+    }
+    if returns.has_return_policy {
+        present += 1;
+    } else {
+        findings.push(finding(
+            CommerceFindingKind::MissingReturnPolicy,
+            Severity::Medium,
+        ));
+    }
+    if reviews.rating_value.is_some() {
+        present += 1;
+    } else {
+        findings.push(finding(CommerceFindingKind::MissingReviews, Severity::Low));
+    }
+
+    let score = (present * 100) / EXPECTED_SIGNALS;
+
+    Some(CommerceAnalysis {
+        price,
+        availability,
+        delivery_time,
+        shipping,
+        returns,
+        reviews,
+        findings,
+        score,
+    })
+}
+
+fn finding(kind: CommerceFindingKind, severity: Severity) -> CommerceFinding {
+    CommerceFinding {
+        kind,
+        severity,
+        message: commerce_finding_text(kind, true),
+    }
+}
+
+/// Single source of truth for finding wording (#406). Analysis bakes English
+/// (`en = true`); the PDF presentation calls it with the run locale.
+pub fn commerce_finding_text(kind: CommerceFindingKind, en: bool) -> String {
+    use CommerceFindingKind::*;
+    match (kind, en) {
+        (MissingPrice, true) => {
+            "No price exposed in the product's structured data (Offer.price).".into()
+        }
+        (MissingPrice, false) => {
+            "Kein Preis in den strukturierten Produktdaten ausgewiesen (Offer.price).".into()
+        }
+        (MissingAvailability, true) => {
+            "No availability exposed in the structured data (Offer.availability).".into()
+        }
+        (MissingAvailability, false) => {
+            "Keine Verfügbarkeit in den strukturierten Daten ausgewiesen (Offer.availability).".into()
+        }
+        (MissingShippingDetails, true) => {
+            "No shipping details in the structured data (OfferShippingDetails) — shipping cost and delivery time are not machine-readable.".into()
+        }
+        (MissingShippingDetails, false) => {
+            "Keine Versandangaben in den strukturierten Daten (OfferShippingDetails) — Versandkosten und Lieferzeit sind nicht maschinenlesbar.".into()
+        }
+        (MissingReturnPolicy, true) => {
+            "No return policy in the structured data (MerchantReturnPolicy).".into()
+        }
+        (MissingReturnPolicy, false) => {
+            "Keine Rückgaberichtlinie in den strukturierten Daten (MerchantReturnPolicy).".into()
+        }
+        (MissingReviews, true) => {
+            "No aggregate rating in the structured data (aggregateRating) — review stars cannot appear in search results.".into()
+        }
+        (MissingReviews, false) => {
+            "Keine Sammelbewertung in den strukturierten Daten (aggregateRating) — Bewertungssterne können nicht in Suchergebnissen erscheinen.".into()
+        }
+    }
+}
+
+// ─── JSON-LD navigation helpers ────────────────────────────────────────────
+
+/// True if the value's `@type` equals or contains `wanted` (handles string and
+/// array `@type`).
+fn schema_is(v: &Value, wanted: &str) -> bool {
+    match v.get("@type") {
+        Some(Value::String(s)) => s == wanted,
+        Some(Value::Array(arr)) => arr.iter().any(|t| t.as_str() == Some(wanted)),
+        _ => false,
+    }
+}
+
+/// The first `Offer` object: the `offers` field (object or array element), else
+/// the root itself if it is an Offer.
+fn first_offer(content: &Value) -> Option<&Value> {
+    match content.get("offers") {
+        Some(Value::Object(_)) => content.get("offers"),
+        Some(Value::Array(arr)) => arr.first(),
+        _ => {
+            if schema_is(content, "Offer") {
+                Some(content)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn extract_price(offer: &Value, product: &Value) -> Option<PriceInfo> {
+    let value = value_to_string(offer.get("price")).or_else(|| {
+        // Some shops use priceSpecification.price.
+        offer
+            .get("priceSpecification")
+            .and_then(|ps| value_to_string(ps.get("price")))
+    })?;
+    let currency = str_field(offer, "priceCurrency")
+        .or_else(|| str_field(product, "priceCurrency"))
+        .or_else(|| {
+            offer
+                .get("priceSpecification")
+                .and_then(|ps| str_field(ps, "priceCurrency"))
+        });
+    let valid_until = str_field(offer, "priceValidUntil");
+    Some(PriceInfo {
+        value,
+        currency,
+        valid_until,
+    })
+}
+
+fn extract_shipping(offer: &Value, product: &Value) -> ShippingInfo {
+    let details = offer
+        .get("shippingDetails")
+        .or_else(|| product.get("shippingDetails"));
+    match details {
+        Some(d) => ShippingInfo {
+            has_shipping_details: true,
+            shipping_rate: d
+                .get("shippingRate")
+                .and_then(|r| value_to_string(r.get("value"))),
+        },
+        None => ShippingInfo::default(),
+    }
+}
+
+fn extract_delivery_time(offer: &Value, product: &Value) -> Option<String> {
+    let details = offer
+        .get("shippingDetails")
+        .or_else(|| product.get("shippingDetails"))?;
+    let dt = details.get("deliveryTime")?;
+    // deliveryTime is usually a ShippingDeliveryTime object; surface a compact
+    // human hint if a transit-time bound is given, else just note its presence.
+    let transit = dt
+        .get("transitTime")
+        .or_else(|| dt.get("handlingTime"))
+        .and_then(|t| t.get("maxValue").or_else(|| t.get("minValue")))
+        .and_then(value_to_string_owned);
+    Some(transit.unwrap_or_else(|| "specified".to_string()))
+}
+
+fn extract_returns(offer: &Value, product: &Value) -> ReturnsInfo {
+    let policy = offer
+        .get("hasMerchantReturnPolicy")
+        .or_else(|| product.get("hasMerchantReturnPolicy"))
+        .or_else(|| {
+            // Some shops emit a standalone MerchantReturnPolicy node.
+            if schema_is(product, "MerchantReturnPolicy") {
+                Some(product)
+            } else {
+                None
+            }
+        });
+    match policy {
+        Some(p) => ReturnsInfo {
+            has_return_policy: true,
+            return_days: value_to_string(p.get("merchantReturnDays")),
+        },
+        None => ReturnsInfo::default(),
+    }
+}
+
+fn extract_reviews(product: &Value) -> ReviewInfo {
+    let agg = product.get("aggregateRating");
+    match agg {
+        Some(a) => ReviewInfo {
+            rating_value: value_to_string(a.get("ratingValue")),
+            review_count: value_to_string(a.get("reviewCount"))
+                .or_else(|| value_to_string(a.get("ratingCount"))),
+        },
+        None => ReviewInfo::default(),
+    }
+}
+
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(str::to_string)
+}
+
+/// Stringify a scalar JSON value (string or number); `None` for other shapes.
+fn value_to_string(v: Option<&Value>) -> Option<String> {
+    v.and_then(value_to_string_owned)
+}
+
+fn value_to_string_owned(v: &Value) -> Option<String> {
+    match v {
+        Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// `https://schema.org/InStock` → `InStock`; leaves bare tokens untouched.
+fn normalize_schema_token(s: String) -> String {
+    s.rsplit('/').next().unwrap_or(&s).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seo::schema::JsonLdSchema;
+
+    fn structured(content: Value) -> StructuredData {
+        StructuredData {
+            json_ld: vec![JsonLdSchema {
+                schema_type: content
+                    .get("@type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                schema_types: vec![],
+                content,
+                is_valid: true,
+            }],
+            types: vec![],
+            has_structured_data: true,
+            rich_snippets_potential: vec![],
+            schema_issues: vec![],
+        }
+    }
+
+    #[test]
+    fn non_product_page_returns_none() {
+        let sd = structured(serde_json::json!({"@type": "Article", "headline": "x"}));
+        assert!(analyze_commerce(&sd).is_none());
+    }
+
+    #[test]
+    fn full_product_scores_100_no_findings() {
+        let sd = structured(serde_json::json!({
+            "@type": "Product",
+            "name": "Widget",
+            "aggregateRating": {"ratingValue": "4.6", "reviewCount": "120"},
+            "offers": {
+                "@type": "Offer",
+                "price": "19.99",
+                "priceCurrency": "EUR",
+                "availability": "https://schema.org/InStock",
+                "shippingDetails": {"@type": "OfferShippingDetails", "shippingRate": {"value": "3.90"}},
+                "hasMerchantReturnPolicy": {"@type": "MerchantReturnPolicy", "merchantReturnDays": "30"}
+            }
+        }));
+        let c = analyze_commerce(&sd).expect("product");
+        assert_eq!(c.score, 100);
+        assert!(c.findings.is_empty());
+        assert_eq!(c.price.unwrap().value, "19.99");
+        assert_eq!(c.availability.as_deref(), Some("InStock"));
+        assert!(c.shipping.has_shipping_details);
+        assert_eq!(c.shipping.shipping_rate.as_deref(), Some("3.90"));
+        assert!(c.returns.has_return_policy);
+        assert_eq!(c.returns.return_days.as_deref(), Some("30"));
+        assert_eq!(c.reviews.rating_value.as_deref(), Some("4.6"));
+    }
+
+    #[test]
+    fn bare_product_flags_all_gaps() {
+        let sd = structured(serde_json::json!({"@type": "Product", "name": "Bare"}));
+        let c = analyze_commerce(&sd).expect("product");
+        assert_eq!(c.score, 0);
+        assert_eq!(c.findings.len(), 5);
+    }
+
+    #[test]
+    fn offers_as_array_is_handled() {
+        let sd = structured(serde_json::json!({
+            "@type": "Product",
+            "offers": [{"@type": "Offer", "price": "5", "priceCurrency": "EUR"}]
+        }));
+        let c = analyze_commerce(&sd).expect("product");
+        assert_eq!(c.price.unwrap().value, "5");
+    }
+
+    #[test]
+    fn english_finding_text_has_no_german_umlauts() {
+        for kind in [
+            CommerceFindingKind::MissingPrice,
+            CommerceFindingKind::MissingAvailability,
+            CommerceFindingKind::MissingShippingDetails,
+            CommerceFindingKind::MissingReturnPolicy,
+            CommerceFindingKind::MissingReviews,
+        ] {
+            let t = commerce_finding_text(kind, true);
+            assert!(
+                !t.chars().any(|c| "äöüÄÖÜß".contains(c)),
+                "EN text has umlaut: {t}"
+            );
+        }
+    }
+}

--- a/src/commerce/module.rs
+++ b/src/commerce/module.rs
@@ -1,0 +1,49 @@
+//! `AuditModule` implementation for the commerce schema pass.
+//!
+//! Derive-only: reads the JSON-LD collected by the SEO module
+//! (`report.discoverability.seo.structured_data`) and writes `report.commerce`.
+//! Self-gating — `analyze_commerce` returns `None` on non-product pages, so the
+//! field stays `None` for landing/editorial pages.
+
+use async_trait::async_trait;
+
+use crate::audit::module::{AuditModule, ModuleContext, ModuleData};
+use crate::audit::{AuditReport, PipelineConfig};
+use crate::error::Result;
+
+use super::analyze_commerce;
+
+pub struct CommerceModule;
+
+#[async_trait]
+impl AuditModule for CommerceModule {
+    fn id(&self) -> &'static str {
+        "commerce"
+    }
+
+    fn label(&self) -> &'static str {
+        "Commerce"
+    }
+
+    fn is_enabled(&self, cfg: &PipelineConfig) -> bool {
+        // Derived from the SEO module's structured data; only meaningful when SEO ran.
+        cfg.check_seo
+    }
+
+    fn depends_on(&self) -> &'static [&'static str] {
+        &["seo"]
+    }
+
+    async fn collect(&self, _ctx: &ModuleContext<'_>) -> Result<ModuleData> {
+        Ok(ModuleData::None)
+    }
+
+    fn derive(&self, report: &mut AuditReport, _locale: &str) -> Result<()> {
+        report.commerce = report
+            .discoverability
+            .seo
+            .as_ref()
+            .and_then(|seo| analyze_commerce(&seo.structured_data));
+        Ok(())
+    }
+}

--- a/src/content_visibility/mod.rs
+++ b/src/content_visibility/mod.rs
@@ -1991,6 +1991,7 @@ mod tests {
             patterns: None,
             screenshot_status: Default::default(),
             best_practices: None,
+            commerce: None,
             consent_banner_detected: false,
             consent_banner_cmp: None,
             consent_banner_dismissed: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod audit;
 pub mod best_practices;
 pub mod browser;
 pub mod cli;
+pub mod commerce;
 pub mod content_visibility;
 pub mod dark_mode;
 pub mod error;

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -365,6 +365,8 @@ pub struct ModuleBlob {
     pub patterns: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub best_practices: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commerce: Option<serde_json::Value>,
 }
 
 /// AI-oriented fix guidance for a single finding group.

--- a/src/output/json/detail.rs
+++ b/src/output/json/detail.rs
@@ -285,6 +285,7 @@ pub(super) fn build_detail(ctx: &AuditContext<'_>, detail_ctx: DetailContext) ->
         best_practices: ctx
             .raw_best_practices
             .map(|m| with_normalized_score(m.to_json(), normalized, "Best Practices")),
+        commerce: ctx.raw_commerce.map(|m| m.to_json()),
     };
 
     PageDetail {

--- a/src/output/module.rs
+++ b/src/output/module.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use crate::ai_visibility::AiVisibilityAnalysis;
 use crate::audit::{AuditReport, PerformanceResults};
 use crate::best_practices::BestPracticesAnalysis;
+use crate::commerce::CommerceAnalysis;
 use crate::content_visibility::ContentVisibilityAnalysis;
 use crate::dark_mode::DarkModeAnalysis;
 #[cfg(feature = "pdf")]
@@ -205,6 +206,19 @@ impl ReportModule for BestPracticesAnalysis {
     }
 }
 
+impl ReportModule for CommerceAnalysis {
+    fn module_key(&self) -> &'static str {
+        "commerce"
+    }
+    fn to_json(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+    #[cfg(feature = "pdf")]
+    fn render_pdf(&self, i18n: &I18n) -> PdfComponents {
+        pdf_marker(self.module_key(), i18n)
+    }
+}
+
 impl ReportModule for TechStackAnalysis {
     fn module_key(&self) -> &'static str {
         "tech_stack"
@@ -275,6 +289,9 @@ pub fn active_modules(report: &AuditReport) -> Vec<(&'static str, Value)> {
     if let Some(ref m) = report.best_practices {
         push(m);
     }
+    if let Some(ref m) = report.commerce {
+        push(m);
+    }
     if let Some(ref m) = report.discoverability.tech_stack {
         push(m);
     }
@@ -310,6 +327,7 @@ pub fn active_report_modules(report: &AuditReport) -> Vec<&dyn ReportModule> {
     push_module!(report.discoverability.ai_visibility);
     push_module!(report.discoverability.content_visibility);
     push_module!(report.best_practices);
+    push_module!(report.commerce);
     push_module!(report.discoverability.tech_stack);
     push_module!(report.patterns);
 

--- a/src/source_quality/mod.rs
+++ b/src/source_quality/mod.rs
@@ -1246,6 +1246,7 @@ mod tests {
             patterns: None,
             screenshot_status: Default::default(),
             best_practices: None,
+            commerce: None,
             consent_banner_detected: false,
             consent_banner_cmp: None,
             consent_banner_dismissed: false,


### PR DESCRIPTION
First slice of the commerce/shop audit (plan: `plans/commerce-audit.md`). Scope chosen by product owner: the low-risk, schema-driven core. This is a deliberate, **shop-gated** extension — it never fires on non-shop pages.

## What it does
New **derive-only** `commerce` module: reads the JSON-LD already collected by the SEO module (`discoverability.seo.structured_data`) — **zero new CDP calls** — and reports whether a product page exposes the commercial info shoppers and search/AI expect as structured data:

- **price** (Offer.price + currency + priceValidUntil)
- **availability** (Offer.availability → normalized token, e.g. `InStock`)
- **shipping** (OfferShippingDetails, shippingRate, deliveryTime)
- **returns** (MerchantReturnPolicy, merchantReturnDays)
- **reviews** (aggregateRating ratingValue/reviewCount)

Plus a `score` (share of the 5 signals present) and findings for each gap.

## Design
- **Self-gating:** `analyze_commerce` returns `None` unless `Product`/`Offer` schema is present → field stays `None` on landing/editorial pages. Verified live (casoon → `commerce` absent; gating correct).
- **#406:** stored struct is canonical English; findings carry a `kind` enum and `commerce_finding_text(kind, en)` is the single text source (EN umlaut guard test).
- **Honest wording:** "not exposed as structured data" (itself an SEO/AI-visibility gap) — it does **not** claim the shop lacks the info on-page.
- Wired as `AuditModule` (`id "commerce"`, `depends_on ["seo"]`, enabled when SEO runs), surfaced in `detail.modules.commerce` + JSON schema; `cache_fmt` bumped to 5 (new field).

## Out of scope (per plan)
Checkout-flow friction, visual/psychology signals — not reliably measurable headless. Slices 2 (site-wide mandatory pages: Impressum/AGB/Widerruf/Versand/Zahlungsarten) and 3 (finer page-type classification) follow.

## Verification
- `clippy --all-targets -- -D warnings` clean on **both** `--no-default-features` and `--all-features`.
- `cargo test --lib --all-features`: 982 passed (incl. new commerce extraction + #406 guard tests). `output_format_tests` (8, schema allows the new field), `report_consistency_tests` (39, serde round-trip), `integration_mocked` (4) green.
- Positive extraction path (full product = score 100, offers-as-array, all-gaps) is unit-tested; live confirmed the module runs + gates without breaking the pipeline.