### PR TITLE
feat(commerce): site-wide trust-pages roll-up (slice 2b)

### DIFF
--- a/docs/json-batch-report.schema.json
+++ b/docs/json-batch-report.schema.json
@@ -101,7 +101,8 @@
         "top_actions": {
           "type": "array",
           "items": { "$ref": "#/$defs/decisionAction" }
-        }
+        },
+        "commerce": { "type": ["object", "null"] }
       }
     },
     "pageEntry": {

--- a/docs/json-report.schema.json
+++ b/docs/json-report.schema.json
@@ -84,7 +84,8 @@
         "top_actions": {
           "type": "array",
           "items": { "$ref": "#/$defs/decisionAction" }
-        }
+        },
+        "commerce": { "type": ["object", "null"] }
       }
     },
     "wcagCoverageSummary": {

--- a/src/commerce/mod.rs
+++ b/src/commerce/mod.rs
@@ -123,6 +123,68 @@ pub struct CommerceFinding {
     pub message: String,
 }
 
+/// Site-wide commerce roll-up across an audited batch (slice 2b).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommerceSiteSummary {
+    /// Trust pages linked on at least one audited page (union).
+    pub trust_pages_linked: TrustPages,
+    /// Mandatory/trust categories not linked anywhere in the audited set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_site_wide: Vec<CommerceFindingKind>,
+    /// Number of audited pages carrying Product schema.
+    pub product_pages: usize,
+}
+
+/// Aggregate per-page commerce results into a site-wide roll-up. Returns `None`
+/// when no audited page produced commerce data (i.e. not a shop).
+pub fn aggregate_site_commerce<'a>(
+    commerces: impl Iterator<Item = &'a CommerceAnalysis>,
+) -> Option<CommerceSiteSummary> {
+    use CommerceFindingKind::*;
+    let mut u = TrustPages::default();
+    let mut product_pages = 0usize;
+    let mut any = false;
+    for c in commerces {
+        any = true;
+        if c.product.is_some() {
+            product_pages += 1;
+        }
+        u.impressum |= c.trust_pages.impressum;
+        u.agb |= c.trust_pages.agb;
+        u.widerruf |= c.trust_pages.widerruf;
+        u.versand |= c.trust_pages.versand;
+        u.zahlungsarten |= c.trust_pages.zahlungsarten;
+        u.kontakt |= c.trust_pages.kontakt;
+    }
+    if !any {
+        return None;
+    }
+    let mut missing = Vec::new();
+    if !u.impressum {
+        missing.push(MissingImpressumLink);
+    }
+    if !u.widerruf {
+        missing.push(MissingWiderrufLink);
+    }
+    if !u.agb {
+        missing.push(MissingAgbLink);
+    }
+    if !u.versand {
+        missing.push(MissingShippingPageLink);
+    }
+    if !u.zahlungsarten {
+        missing.push(MissingPaymentLink);
+    }
+    if !u.kontakt {
+        missing.push(MissingContactLink);
+    }
+    Some(CommerceSiteSummary {
+        trust_pages_linked: u,
+        missing_site_wide: missing,
+        product_pages,
+    })
+}
+
 const EXPECTED_PRODUCT_SIGNALS: u32 = 5;
 
 /// Analyze commerce signals. `anchor_texts` are the page's link anchor texts

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -177,6 +177,10 @@ pub struct UnifiedSummary {
     /// Internal targets linked by audited pages but absent from the sitemap.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub linked_not_in_sitemap: Vec<String>,
+    /// Site-wide commerce roll-up (batch only): union of mandatory/trust-page
+    /// links across the audited shop pages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commerce: Option<crate::commerce::CommerceSiteSummary>,
 }
 
 #[derive(Debug, Serialize)]
@@ -553,6 +557,12 @@ impl UnifiedReport {
             sitemap_http_issues: presentation.portfolio_summary.sitemap_http_issues.clone(),
             orphan_sitemap_urls: presentation.portfolio_summary.orphan_sitemap_urls.clone(),
             linked_not_in_sitemap: presentation.portfolio_summary.linked_not_in_sitemap.clone(),
+            commerce: crate::commerce::aggregate_site_commerce(
+                batch_report
+                    .reports
+                    .iter()
+                    .filter_map(|r| r.commerce.as_ref()),
+            ),
         };
 
         let mut collection_errors: Vec<ReportError> = Vec::new();
@@ -708,6 +718,7 @@ impl UnifiedReport {
             sitemap_http_issues: Vec::new(),
             orphan_sitemap_urls: Vec::new(),
             linked_not_in_sitemap: Vec::new(),
+            commerce: None,
         };
 
         UnifiedReport {
@@ -784,6 +795,7 @@ impl UnifiedReport {
             sitemap_http_issues: Vec::new(),
             orphan_sitemap_urls: Vec::new(),
             linked_not_in_sitemap: Vec::new(),
+            commerce: None,
         };
 
         UnifiedReport {

--- a/src/output/json/tests.rs
+++ b/src/output/json/tests.rs
@@ -680,6 +680,7 @@ fn test_collection_errors_serialized_when_present() {
             sitemap_http_issues: vec![],
             orphan_sitemap_urls: vec![],
             linked_not_in_sitemap: vec![],
+            commerce: None,
         },
         sample: None,
         pages: vec![],


### PR DESCRIPTION
Thin follow-up to slice 2: rolls the per-page commerce `trust_pages` up to a site-wide view in the **batch** summary.

## What changed
- New `CommerceSiteSummary { trust_pages_linked (union), missing_site_wide, product_pages }` + `aggregate_site_commerce` (pure, over `&CommerceAnalysis`) in the commerce module.
- `UnifiedSummary.commerce: Option<CommerceSiteSummary>` — populated in `UnifiedReport::batch` from the raw audited reports (union of which mandatory/trust pages are linked anywhere, which are missing site-wide, product-page count). `None` for single reports.
- Schema: `commerce` added to both summary defs (object/null; summaries are `additionalProperties:false`). Output-only — no cache change.

## Verification
- `clippy --all-targets -- -D warnings` clean on both feature sets.
- Full `cargo test --features pdf` + `cargo test --no-default-features` suites green. `output_format_tests` (8, incl. batch-schema validation of the new field) + `report_consistency_tests` (39) pass.

With this, the multi-page value the topic-list called for is complete: per-page mandatory-link detection (#497) + site-wide union (this). Slice 3 (finer page-type classification) is the remaining planned piece.